### PR TITLE
[#2][FEATURE] 공통_공통 컴포넌트 구현

### DIFF
--- a/src/components/common/Button/index.tsx
+++ b/src/components/common/Button/index.tsx
@@ -1,0 +1,20 @@
+import { StButton } from './style';
+
+export interface Props {
+  type: 'button' | 'submit';
+  text: string;
+  onClick?: () => void;
+  disabled?: boolean;
+}
+
+function Button(props: Props) {
+  const { type, text, onClick, disabled = false } = props;
+
+  return (
+    <StButton type={type} onClick={onClick} disabled={disabled}>
+      {text}
+    </StButton>
+  );
+}
+
+export default Button;

--- a/src/components/common/Button/style.ts
+++ b/src/components/common/Button/style.ts
@@ -1,0 +1,31 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import { Props } from './index';
+
+export const StButton = styled.button<Pick<Props, 'type'>>`
+  height: 4.8rem;
+  padding: 1.6rem 2.4rem;
+  font-size: 1.6rem;
+  line-height: 1;
+  font-weight: 600;
+  border-radius: 4rem;
+  &:disabled {
+    background-color: ${({ theme }) => theme.color.grayscale.gray30};
+    border: 1px solid ${({ theme }) => theme.color.grayscale.gray30};
+    color: ${({ theme }) => theme.color.grayscale.white100};
+    cursor: default;
+  }
+  ${({ theme, type }) =>
+    type === 'button'
+      ? css`
+          background-color: ${theme.color.grayscale.white100};
+          border: 1px solid ${theme.color.grayscale.gray30};
+          color: ${theme.color.grayscale.gray60};
+        `
+      : css`
+          background-color: ${theme.color.main.purple100};
+          border: 1px solid ${theme.color.main.purple100};
+          color: ${theme.color.grayscale.white100};
+        `}
+`;

--- a/src/components/common/Footer/index.tsx
+++ b/src/components/common/Footer/index.tsx
@@ -11,7 +11,9 @@ function Footer(props: Props) {
 
   return (
     <StFooterWrap>
-      <StFooter>{children}</StFooter>
+      <StFooter>
+        <div>{children}</div>
+      </StFooter>
     </StFooterWrap>
   );
 }

--- a/src/components/common/Footer/style.ts
+++ b/src/components/common/Footer/style.ts
@@ -10,7 +10,13 @@ export const StFooter = styled.footer`
   left: 22rem;
   width: calc(100% - 22rem);
   height: 11rem;
-  padding: 2rem 12rem;
   background-color: ${({ theme }) => theme.color.grayscale.gray20};
   box-shadow: 6px 0 40px 0 rgba(0, 0, 0, 0.06);
+  & > div {
+    width: 100%;
+    height: 100%;
+    max-width: 98rem;
+    margin: 0 auto;
+    padding: 2rem 0;
+  }
 `;

--- a/src/components/common/ListWrapper/index.tsx
+++ b/src/components/common/ListWrapper/index.tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from 'react';
+
+import { StList } from './style';
+
+interface Props {
+  children: ReactNode;
+}
+
+/**
+ * 리스트에 스타일 입혀주는 Wrapper Component
+ * @param children thead는 th를 tr로 감싸고, tbody는 td를 tr로 감싸야함
+ * @returns 리스트에 스타일을 입혀서 반환
+ */
+function ListWrapper(props: Props) {
+  const { children } = props;
+
+  return <StList>{children}</StList>;
+}
+
+export default ListWrapper;

--- a/src/components/common/ListWrapper/style.ts
+++ b/src/components/common/ListWrapper/style.ts
@@ -1,0 +1,42 @@
+import styled from '@emotion/styled';
+
+import { body2, caption1 } from '@/styles/fonts';
+
+export const StList = styled.table`
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0 1.6rem;
+  thead > tr {
+    ${caption1}
+    font-weight: 400;
+    color: ${({ theme }) => theme.color.grayscale.black40};
+    & > th {
+      padding-bottom: 2.4rem;
+    }
+  }
+  tbody > tr {
+    ${body2}
+    height: 7rem;
+    color: ${({ theme }) => theme.color.grayscale.black40};
+    & > td {
+      height: inherit;
+      text-align: center;
+      vertical-align: middle;
+      background-color: ${({ theme }) => theme.color.grayscale.white100};
+      border-top: 0.5px solid ${({ theme }) => theme.color.grayscale.gray30};
+      border-bottom: 0.5px solid ${({ theme }) => theme.color.grayscale.gray30};
+    }
+    & > td:first-of-type {
+      border-top-left-radius: 1rem;
+      border-bottom-left-radius: 1rem;
+      border: 0.5px solid ${({ theme }) => theme.color.grayscale.gray30};
+      border-right: none;
+    }
+    & > td:last-of-type {
+      border-top-right-radius: 1rem;
+      border-bottom-right-radius: 1rem;
+      border: 0.5px solid ${({ theme }) => theme.color.grayscale.gray30};
+      border-left: none;
+    }
+  }
+`;

--- a/src/components/common/ListWrapper/style.ts
+++ b/src/components/common/ListWrapper/style.ts
@@ -10,6 +10,7 @@ export const StList = styled.table`
     ${caption1}
     font-weight: 400;
     color: ${({ theme }) => theme.color.grayscale.black40};
+    opacity: 0.7;
     & > th {
       padding-bottom: 2.4rem;
     }

--- a/src/components/common/PartFilter/index.tsx
+++ b/src/components/common/PartFilter/index.tsx
@@ -1,0 +1,27 @@
+import { partList, partTranslator } from '@/utils/translator';
+
+import { FilterButton, StPartFilter } from './style';
+
+interface Props {
+  selected: PART;
+  onChangePart: (part: PART) => void;
+}
+
+function PartFilter(props: Props) {
+  const { selected, onChangePart } = props;
+
+  return (
+    <StPartFilter>
+      {partList.map((part) => (
+        <FilterButton
+          key={part}
+          selected={selected === part}
+          onClick={() => onChangePart(part)}>
+          {partTranslator[part]}
+        </FilterButton>
+      ))}
+    </StPartFilter>
+  );
+}
+
+export default PartFilter;

--- a/src/components/common/PartFilter/style.ts
+++ b/src/components/common/PartFilter/style.ts
@@ -6,6 +6,7 @@ export const StPartFilter = styled.div`
   background-color: ${({ theme }) => theme.color.grayscale.gray10};
   border-radius: 4rem;
   width: fit-content;
+  box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.02);
 `;
 export const FilterButton = styled.button<{ selected: boolean }>`
   font-size: 1.4rem;

--- a/src/components/common/PartFilter/style.ts
+++ b/src/components/common/PartFilter/style.ts
@@ -1,0 +1,28 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const StPartFilter = styled.div`
+  padding: 0.8rem 1rem;
+  background-color: ${({ theme }) => theme.color.grayscale.gray10};
+  border-radius: 4rem;
+  width: fit-content;
+`;
+export const FilterButton = styled.button<{ selected: boolean }>`
+  font-size: 1.4rem;
+  line-height: 1.7rem;
+  padding: 1.1rem 3.6rem;
+  border-radius: 4rem;
+  transition: all 0.2s;
+  ${({ theme, selected }) =>
+    selected
+      ? css`
+          font-weight: 600;
+          color: ${theme.color.grayscale.gray10};
+          background-color: ${theme.color.main.purple100};
+        `
+      : css`
+          font-weight: 400;
+          color: ${theme.color.grayscale.gray80};
+          background-color: ${theme.color.grayscale.gray10};
+        `}
+`;

--- a/src/data/sessionData.ts
+++ b/src/data/sessionData.ts
@@ -1,0 +1,218 @@
+export const attendanceInit: Attendance = {
+  round: 0,
+  status: 'ABSENT',
+  date: '- -',
+};
+
+export const sessionDetailDummy: SessionDetail = {
+  name: '테스트',
+  generation: 32,
+  part: 'SERVER',
+  attribute: 'SEMINAR',
+  members: [
+    {
+      name: '소현',
+      university: '앙중대',
+      attendances: [
+        {
+          round: 1,
+          status: 'ABSENT',
+          date: '23/01/01 11:00',
+        },
+        {
+          round: 2,
+          status: 'ABSENT',
+          date: '23/01/01 11:00',
+        },
+      ],
+      score: 0,
+    },
+    {
+      name: '용택',
+      university: '숭실숭실',
+      attendances: [
+        {
+          round: 1,
+          status: 'ABSENT',
+          date: '23/01/01 11:00',
+        },
+        {
+          round: 2,
+          status: 'ABSENT',
+          date: '23/01/01 11:00',
+        },
+      ],
+      score: 0,
+    },
+    {
+      name: '용택',
+      university: '숭실숭실',
+      attendances: [
+        {
+          round: 1,
+          status: 'ABSENT',
+          date: '23/01/01 11:00',
+        },
+        {
+          round: 2,
+          status: 'ABSENT',
+          date: '23/01/01 11:00',
+        },
+      ],
+      score: 0,
+    },
+    {
+      name: '용택',
+      university: '숭실숭실',
+      attendances: [
+        {
+          round: 1,
+          status: 'ABSENT',
+          date: '23/01/01 11:00',
+        },
+        {
+          round: 2,
+          status: 'ABSENT',
+          date: '23/01/01 11:00',
+        },
+      ],
+      score: 0,
+    },
+    {
+      name: '용택',
+      university: '숭실숭실',
+      attendances: [
+        {
+          round: 1,
+          status: 'ABSENT',
+          date: '23/01/01 11:00',
+        },
+        {
+          round: 2,
+          status: 'ABSENT',
+          date: '23/01/01 11:00',
+        },
+      ],
+      score: 0,
+    },
+    {
+      name: '용택',
+      university: '숭실숭실',
+      attendances: [
+        {
+          round: 1,
+          status: 'ABSENT',
+          date: '23/01/01 11:00',
+        },
+        {
+          round: 2,
+          status: 'ABSENT',
+          date: '23/01/01 11:00',
+        },
+      ],
+      score: 0,
+    },
+    {
+      name: '용택',
+      university: '숭실숭실',
+      attendances: [
+        {
+          round: 1,
+          status: 'ABSENT',
+          date: '23/01/01 11:00',
+        },
+        {
+          round: 2,
+          status: 'ABSENT',
+          date: '23/01/01 11:00',
+        },
+      ],
+      score: 0,
+    },
+    {
+      name: '용택',
+      university: '숭실숭실',
+      attendances: [
+        {
+          round: 1,
+          status: 'ABSENT',
+          date: '23/01/01 11:00',
+        },
+        {
+          round: 2,
+          status: 'ABSENT',
+          date: '23/01/01 11:00',
+        },
+      ],
+      score: 0,
+    },
+    {
+      name: '용택',
+      university: '숭실숭실',
+      attendances: [
+        {
+          round: 1,
+          status: 'ABSENT',
+          date: '23/01/01 11:00',
+        },
+        {
+          round: 2,
+          status: 'ABSENT',
+          date: '23/01/01 11:00',
+        },
+      ],
+      score: 0,
+    },
+    {
+      name: '용택',
+      university: '숭실숭실',
+      attendances: [
+        {
+          round: 1,
+          status: 'ABSENT',
+          date: '23/01/01 11:00',
+        },
+        {
+          round: 2,
+          status: 'ABSENT',
+          date: '23/01/01 11:00',
+        },
+      ],
+      score: 0,
+    },
+    {
+      name: '용택',
+      university: '숭실숭실',
+      attendances: [
+        {
+          round: 1,
+          status: 'ABSENT',
+          date: '23/01/01 11:00',
+        },
+        {
+          round: 2,
+          status: 'ABSENT',
+          date: '23/01/01 11:00',
+        },
+      ],
+      score: 0,
+    },
+    {
+      name: '용택',
+      university: '숭실숭실',
+      attendances: [
+        {
+          round: 1,
+          status: 'ABSENT',
+          date: '23/01/01 11:00',
+        },
+        {
+          round: 2,
+          status: 'ABSENT',
+          date: '23/01/01 11:00',
+        },
+      ],
+      score: 0,
+    },
+  ],
+};

--- a/src/pages/attendanceAdmin/session/[id].tsx
+++ b/src/pages/attendanceAdmin/session/[id].tsx
@@ -1,3 +1,6 @@
+import styled from '@emotion/styled';
+
+import Button from '@/components/common/Button';
 import Footer from '@/components/common/Footer';
 import ListWrapper from '@/components/common/ListWrapper';
 import { attendanceInit, sessionDetailDummy } from '@/data/sessionData';
@@ -49,9 +52,47 @@ function SessionDetailPage() {
           })}
         </tbody>
       </ListWrapper>
-      <Footer>Footer</Footer>
+      <Footer>
+        <StFooterContents>
+          <div className="code-wrap">
+            <p>1차 출석코드</p>
+            <p>80182</p>
+          </div>
+          <div className="button-wrap">
+            <Button type="submit" text="1차 출석 시작하기" />
+            <Button type="submit" text="2차 출석 시작하기" disabled />
+          </div>
+        </StFooterContents>
+      </Footer>
     </>
   );
 }
+
+const StFooterContents = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  .code-wrap {
+    display: flex;
+    align-items: center;
+    gap: 1.6rem;
+    font-size: 1.6rem;
+    line-height: 2.2rem;
+    font-weight: 600;
+    & > p:first-of-type {
+      color: ${({ theme }) => theme.color.grayscale.gray100};
+    }
+    & > p:last-of-type {
+      color: ${({ theme }) => theme.color.grayscale.white100};
+      background-color: ${({ theme }) => theme.color.main.purple100};
+      padding: 0.4rem 1rem;
+      border-radius: 0.4rem;
+    }
+  }
+  .button-wrap {
+    display: flex;
+    gap: 2.4rem;
+  }
+`;
 
 export default SessionDetailPage;

--- a/src/pages/attendanceAdmin/session/[id].tsx
+++ b/src/pages/attendanceAdmin/session/[id].tsx
@@ -1,5 +1,57 @@
+import Footer from '@/components/common/Footer';
+import ListWrapper from '@/components/common/ListWrapper';
+import { attendanceInit, sessionDetailDummy } from '@/data/sessionData';
+import { precision } from '@/utils';
+
 function SessionDetailPage() {
-  return <div></div>;
+  const HEADER_LABELS = [
+    '순번',
+    '회원명',
+    '학교명',
+    '1차 출석 상태',
+    '1차 출석 일시',
+    '2차 출석 상태',
+    '2차 출석 일시',
+    '변동점수',
+  ];
+
+  return (
+    <>
+      <ListWrapper>
+        <thead>
+          <tr>
+            {HEADER_LABELS.map((label) => (
+              <th key={label}>{label}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {sessionDetailDummy.members.map((member, index) => {
+            const firstRound =
+              member.attendances.find((item) => item.round === 1) ??
+              attendanceInit;
+            const secondRound =
+              member.attendances.find((item) => item.round === 2) ??
+              attendanceInit;
+
+            return (
+              <tr key={`${member.name}-${member.university}`}>
+                <td>{precision(index + 1, 2)}</td>
+                <td>{member.name}</td>
+                <td>{member.university}</td>
+                <td>{firstRound.status}</td>
+                <td>{firstRound.date}</td>
+                <td>{secondRound.status}</td>
+                <td>{secondRound.date}</td>
+                <td>{member.score}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </ListWrapper>
+      <Footer>Footer</Footer>
+    </>
+  );
 }
 
 export default SessionDetailPage;

--- a/src/pages/attendanceAdmin/session/[id].tsx
+++ b/src/pages/attendanceAdmin/session/[id].tsx
@@ -1,8 +1,10 @@
 import styled from '@emotion/styled';
+import { useState } from 'react';
 
 import Button from '@/components/common/Button';
 import Footer from '@/components/common/Footer';
 import ListWrapper from '@/components/common/ListWrapper';
+import PartFilter from '@/components/common/PartFilter';
 import { attendanceInit, sessionDetailDummy } from '@/data/sessionData';
 import { precision } from '@/utils';
 
@@ -18,8 +20,15 @@ function SessionDetailPage() {
     '변동점수',
   ];
 
+  const [selectedPart, setSelectedPart] = useState<PART>('ALL');
+
+  const onChangePart = (part: PART) => {
+    setSelectedPart(part);
+  };
+
   return (
     <>
+      <PartFilter selected={selectedPart} onChangePart={onChangePart} />
       <ListWrapper>
         <thead>
           <tr>

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -52,6 +52,13 @@ const global: Interpolation<Theme> = (theme: Theme) => css`
   }
   @font-face {
     font-family: 'SUIT';
+    src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_suit@1.0/SUIT-SemiBold.woff2')
+      format('woff2');
+    font-weight: 600;
+    font-style: normal;
+  }
+  @font-face {
+    font-family: 'SUIT';
     src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_suit@1.0/SUIT-Bold.woff2')
       format('woff2');
     font-weight: 700;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,5 @@
+export const precision = (num: number, precisionNum: number) => {
+  const numToString = num + '';
+  const numLength = numToString.length;
+  return '0'.repeat(precisionNum - numLength) + numToString;
+};

--- a/src/utils/translator.ts
+++ b/src/utils/translator.ts
@@ -1,0 +1,18 @@
+export const partList: PART[] = [
+  'ALL',
+  'PLAN',
+  'DESIGN',
+  'SERVER',
+  'IOS',
+  'ANDROID',
+  'WEB',
+];
+export const partTranslator: Record<PART, string> = {
+  ALL: '전체',
+  PLAN: '기획',
+  DESIGN: '디자인',
+  SERVER: '서버',
+  IOS: 'iOS',
+  ANDROID: 'AOS',
+  WEB: '웹',
+};


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->
 공통으로 사용하는 ListWrapper, Button, Footer, PartFilter를 구현했어요

## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->
- 폰트 스타일이 아직 정리가 안 돼서 디자인 시스템과 다른 폰트는 직접 입력했어요. 정리가 끝나면 추후에 변경하도록 할게요
- ListWrapper는 리스트로 구현하면 굉장히 복잡해질 것 같아서 테이블로 구현했어요. 그래서 css가 조금 요상해보일지도? 테이블 css 커스텀이 생각보다 까다롭더라구요
- PartFilter에서 파트 리스트를 불러올 때 `Object.keys(partTranslator)` 를 사용하려다가, 이렇게 하면 `as`를 써야해서 `partList` 변수를 별도로 만들었어요
- Footer는 페이지에 따라 유무가 달라지므로 각 페이지에서 관리하도록 구현했어요. 이 과정에서 부득이하게 페이지 내에서 emotion을 사용해야하는데, 어떻게 관리하면 좋을까요? 피클은 Next가 아니라서 페이지 내에서 style 파일을 분리했더라구요.
- 더미데이터는 API 연결 후에 삭제 예정!

## 😭 어려웠던 점
- 테이블 커스텀...

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->
