### PR TITLE
[#24] [REFACTOR] PartFilter 의존성 분리

### DIFF
--- a/src/components/common/FilterButton/index.tsx
+++ b/src/components/common/FilterButton/index.tsx
@@ -1,0 +1,29 @@
+import {
+  FilterButtonItem,
+  StWrapper,
+} from '@/components/common/FilterButton/style';
+
+interface Props<T extends string | number> {
+  list: T[];
+  translator: Record<T, string>;
+  onChange: (item: T) => void;
+  selected: T;
+}
+
+function FilterButton<T extends string | number>(props: Props<T>) {
+  const { list, translator, selected, onChange } = props;
+  return (
+    <StWrapper>
+      {list.map((item: T) => (
+        <FilterButtonItem
+          key={item}
+          selected={selected === item}
+          onClick={() => onChange(item)}>
+          {translator[item]}
+        </FilterButtonItem>
+      ))}
+    </StWrapper>
+  );
+}
+
+export default FilterButton;

--- a/src/components/common/FilterButton/style.ts
+++ b/src/components/common/FilterButton/style.ts
@@ -1,14 +1,14 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
-export const StPartFilter = styled.div`
+export const StWrapper = styled.div`
   padding: 0.8rem 1rem;
   background-color: ${({ theme }) => theme.color.grayscale.gray10};
   border-radius: 4rem;
   width: fit-content;
   box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.02);
 `;
-export const FilterButton = styled.button<{ selected: boolean }>`
+export const FilterButtonItem = styled.button<{ selected: boolean }>`
   font-size: 1.4rem;
   line-height: 1.7rem;
   padding: 1.1rem 3.6rem;

--- a/src/components/common/PartFilter/index.tsx
+++ b/src/components/common/PartFilter/index.tsx
@@ -1,6 +1,5 @@
+import FilterButton from '@/components/common/FilterButton';
 import { partList, partTranslator } from '@/utils/translator';
-
-import { FilterButton, StPartFilter } from './style';
 
 interface Props {
   selected: PART;
@@ -11,16 +10,12 @@ function PartFilter(props: Props) {
   const { selected, onChangePart } = props;
 
   return (
-    <StPartFilter>
-      {partList.map((part) => (
-        <FilterButton
-          key={part}
-          selected={selected === part}
-          onClick={() => onChangePart(part)}>
-          {partTranslator[part]}
-        </FilterButton>
-      ))}
-    </StPartFilter>
+    <FilterButton<PART>
+      list={partList}
+      selected={selected}
+      onChange={onChangePart}
+      translator={partTranslator}
+    />
   );
 }
 


### PR DESCRIPTION
## ✨ 구현 기능 명세
#24 
- 공홈 어드민에서 PartFilter 컴포넌트와 같이 ButtonGroup이 필요한 케이스가 생겼습니다.
-  하지만 PartList와 의존성이 강해서 분리를 하였습니다.


## ✅ PR Point

## 😭 어려웠던 점
