### PR TITLE
[#44][REFACTOR] 기수 선택시 API 재호출

### DIFF
--- a/src/components/attendanceAdmin/session/CreateSessionModal/index.tsx
+++ b/src/components/attendanceAdmin/session/CreateSessionModal/index.tsx
@@ -102,7 +102,6 @@ function CreateSessionModal(props: Props) {
         attribute: translatedAttribute,
         generation: parseInt(currentGeneration),
       };
-      console.log(submitContents);
 
       createSession(submitContents);
       onClose();

--- a/src/components/attendanceAdmin/session/CreateSessionModal/index.tsx
+++ b/src/components/attendanceAdmin/session/CreateSessionModal/index.tsx
@@ -3,12 +3,14 @@ import 'react-datepicker/dist/react-datepicker.css';
 import { useEffect, useState } from 'react';
 import React from 'react';
 import DatePicker from 'react-datepicker';
+import { useRecoilValue } from 'recoil';
 
 import { IcCheckBox, IcModalClose } from '@/assets/icons';
 import Button from '@/components/common/Button';
 import DropDown from '@/components/common/DropDown';
 import IcDropdown from '@/components/common/icons/IcDropDown';
 import { useCreateSession } from '@/hooks/useCreateSession';
+import { currentGenerationState } from '@/recoil/atom';
 import {
   partList,
   partTranslator,
@@ -54,6 +56,8 @@ function CreateSessionModal(props: Props) {
   const [buttonDisabled, setButtonDisabled] = useState<boolean>(true);
   const [buttonClicked, setButtonClicked] = useState(false);
 
+  const currentGeneration = useRecoilValue(currentGenerationState);
+
   const { createSession } = useCreateSession(part);
 
   useEffect(() => {
@@ -96,8 +100,9 @@ function CreateSessionModal(props: Props) {
         startDate: `${date} ${startTime}`,
         endDate: `${date} ${endTime}`,
         attribute: translatedAttribute,
-        generation: 32,
+        generation: parseInt(currentGeneration),
       };
+      console.log(submitContents);
 
       createSession(submitContents);
       onClose();

--- a/src/components/attendanceAdmin/session/SessionList/index.tsx
+++ b/src/components/attendanceAdmin/session/SessionList/index.tsx
@@ -1,10 +1,12 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+import { useRecoilValue } from 'recoil';
 
 import ListWrapper from '@/components/common/ListWrapper';
 import Loading from '@/components/common/Loading';
 import Modal from '@/components/common/modal';
 import PartFilter from '@/components/common/PartFilter';
+import { currentGenerationState } from '@/recoil/atom';
 import { deleteSession, useGetSessionList } from '@/services/api/lecture';
 import { precision } from '@/utils';
 import { getAuthHeader } from '@/utils/auth';
@@ -51,9 +53,10 @@ function SessionList() {
   const [selectedPart, setSelectedPart] = useState<PART>('ALL');
   const [lectureData, setLectureData] = useState<LectureList[]>([]);
   const [isDetailOpen, setIsDetailOpen] = useState<Boolean>(false);
+  const currentGeneration = useRecoilValue(currentGenerationState);
 
   const { data, isLoading, isError, error } = useGetSessionList(
-    32,
+    parseInt(currentGeneration),
     selectedPart,
     getAuthHeader(),
   );

--- a/src/components/attendanceAdmin/totalScore/MemberList/index.tsx
+++ b/src/components/attendanceAdmin/totalScore/MemberList/index.tsx
@@ -1,9 +1,11 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+import { useRecoilValue } from 'recoil';
 
 import ListWrapper from '@/components/common/ListWrapper';
 import Loading from '@/components/common/Loading';
 import PartFilter from '@/components/common/PartFilter';
+import { currentGenerationState } from '@/recoil/atom';
 import { useGetMemberList } from '@/services/api/member';
 import { precision } from '@/utils';
 import { getAuthHeader } from '@/utils/auth';
@@ -46,9 +48,10 @@ function MemberList() {
   const [selectedMember, setSelectedMember] = useState<ScoreMember | null>(
     null,
   );
+  const currentGeneration = useRecoilValue(currentGenerationState);
 
   const { data, isLoading, isError, error } = useGetMemberList(
-    32,
+    parseInt(currentGeneration),
     selectedPart,
     getAuthHeader(),
   );

--- a/src/components/common/Nav/index.tsx
+++ b/src/components/common/Nav/index.tsx
@@ -1,7 +1,9 @@
 import { useRouter } from 'next/router';
 import React, { useState } from 'react';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { IcNavMenu } from '@/assets/icons';
+import { currentGenerationState } from '@/recoil/atom';
 import { MENU_LIST } from '@/utils/nav';
 
 import DropDown from '../DropDown';
@@ -14,12 +16,20 @@ import {
   StSubMenu,
 } from './style';
 
-const GENERATION_LIST = ['32'];
+const GENERATION_LIST = ['33', '32'];
 
 function Nav() {
   const router = useRouter();
-  const [generation, setGeneration] = useState<string>(GENERATION_LIST[0]);
+  const currentGeneration = useRecoilValue(currentGenerationState);
+  const setCurrentGeneration = useSetRecoilState<string>(
+    currentGenerationState,
+  );
   const [isDropdownOn, setIsDropdownOn] = useState<boolean>(false);
+
+  const handleSelectedGeneration = (selectedGeneration: string) => {
+    setCurrentGeneration(selectedGeneration);
+    setIsDropdownOn(false);
+  };
 
   const handleSubMenuClick = (path: string) => {
     router.push(path);
@@ -31,10 +41,16 @@ function Nav() {
         <StSoptLogo>SOPT</StSoptLogo>
         <StGenerationDropdown>
           <div onClick={() => setIsDropdownOn(!isDropdownOn)}>
-            <span>{generation}기</span>
+            <span>{currentGeneration}기</span>
             <IcDropDown />
           </div>
-          {isDropdownOn && <DropDown list={GENERATION_LIST} type={'select'} />}
+          {isDropdownOn && (
+            <DropDown
+              list={GENERATION_LIST}
+              type={'select'}
+              onItemSelected={handleSelectedGeneration}
+            />
+          )}
         </StGenerationDropdown>
       </header>
       {MENU_LIST.map((menu) => (

--- a/src/hooks/useCreateSession.ts
+++ b/src/hooks/useCreateSession.ts
@@ -1,5 +1,7 @@
 import { useMutation, useQueryClient } from 'react-query';
+import { useRecoilValue } from 'recoil';
 
+import { currentGenerationState } from '@/recoil/atom';
 import { postNewSession } from '@/services/api/lecture';
 import { getAuthHeader } from '@/utils/auth';
 import { partTranslator } from '@/utils/session';
@@ -16,13 +18,15 @@ interface MutationInput {
 export const useCreateSession = (part: string) => {
   const queryClient = useQueryClient();
 
+  const currentGeneration = useRecoilValue(currentGenerationState);
+
   const mutation = useMutation<void, ProjectError, MutationInput, SessionBase>(
     ({ newData, authHeader }) => postNewSession(newData, authHeader),
     {
       onSuccess: () => {
         queryClient.invalidateQueries([
           'sessionList',
-          32,
+          parseInt(currentGeneration),
           partTranslator[part],
           getAuthHeader(),
         ]);

--- a/src/recoil/atom.ts
+++ b/src/recoil/atom.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const currentGenerationState = atom<string>({
+  key: 'currentGenerationState',
+  default: '32',
+});


### PR DESCRIPTION
## ✨ 구현 기능 명세

- 기수 선택 드롭다운 값에 따라 보여지는 정보가 달라지도록 리팩토링 하였습니다.
- 선택된 기수의 화면에서 세션 생성시 해당 기수에 맞는 리스트에 새션이 생성되도록 하였습니다.

## ✅ PR Point

각 함수가 받는 인자는 number, 드롭다운에서 인자로 받는 값은 string 인데, 이것을 변환하는데 `parseInt()` 를 사용했습니다.
이대로 두는게 좋을까요 드롭다운의 타입을 좀 더 유연하게 변경하는게 좋을까요?
타입 안정을 위해서는 이대로 두는게 더 좋을 것 같다고 생각하는데 어떻게 생각하시는지 궁급합니다!


https://github.com/sopt-makers/sopt-operation-frontend/assets/97586683/17896dc9-2f34-41bb-90a9-55b770a1060b


