### PR TITLE
[#54][REFACTOR] ISO 8601 형식 적용

### DIFF
--- a/src/components/attendanceAdmin/session/SessionList/index.tsx
+++ b/src/components/attendanceAdmin/session/SessionList/index.tsx
@@ -56,7 +56,6 @@ function SessionList() {
   const [lectureData, setLectureData] = useState<LectureList[]>([]);
   const [isDetailOpen, setIsDetailOpen] = useState<Boolean>(false);
   const [selectedLecture, setSelectedLecture] = useState<number>(0);
-  const [formattedDates, setFormattedDates] = useState<string[]>([]);
   const currentGeneration = useRecoilValue(currentGenerationState);
 
   const { data, isLoading, isError, error } = useGetSessionList(

--- a/src/components/attendanceAdmin/totalScore/MemberDetail/index.tsx
+++ b/src/components/attendanceAdmin/totalScore/MemberDetail/index.tsx
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import { useEffect, useState } from 'react';
 
 import { IcModalClose } from '@/assets/icons';
@@ -92,7 +93,12 @@ function MemberDetail(props: Props) {
                 const secondRound =
                   lecture.attendances.find((item) => item.round === 2) ??
                   scoreDetailAttendanceInit;
-
+                const firstRoundTime = dayjs(firstRound.date).format(
+                  'YYYY/MM/DD HH:mm',
+                );
+                const secondRoundTime = dayjs(secondRound.date).format(
+                  'YYYY/MM/DD HH:mm',
+                );
                 return (
                   <tr key={lecture.lecture}>
                     <td style={{ width: TABLE_WIDTH[0] }}>
@@ -108,7 +114,7 @@ function MemberDetail(props: Props) {
                       }}>
                       {firstRound.status}
                     </td>
-                    <td style={{ width: TABLE_WIDTH[3] }}>{firstRound.date}</td>
+                    <td style={{ width: TABLE_WIDTH[3] }}>{firstRoundTime}</td>
                     <td
                       style={{
                         width: TABLE_WIDTH[4],
@@ -116,9 +122,7 @@ function MemberDetail(props: Props) {
                       }}>
                       {secondRound.status}
                     </td>
-                    <td style={{ width: TABLE_WIDTH[5] }}>
-                      {secondRound.date}
-                    </td>
+                    <td style={{ width: TABLE_WIDTH[5] }}>{secondRoundTime}</td>
                     <td
                       style={{
                         width: TABLE_WIDTH[6],

--- a/src/components/attendanceAdmin/totalScore/MemberDetail/index.tsx
+++ b/src/components/attendanceAdmin/totalScore/MemberDetail/index.tsx
@@ -93,10 +93,10 @@ function MemberDetail(props: Props) {
                 const secondRound =
                   lecture.attendances.find((item) => item.round === 2) ??
                   scoreDetailAttendanceInit;
-                const firstRoundTime = dayjs(firstRound.date).format(
+                const firstRoundDate = dayjs(firstRound.date).format(
                   'YYYY/MM/DD HH:mm',
                 );
-                const secondRoundTime = dayjs(secondRound.date).format(
+                const secondRoundDate = dayjs(secondRound.date).format(
                   'YYYY/MM/DD HH:mm',
                 );
                 return (
@@ -114,7 +114,7 @@ function MemberDetail(props: Props) {
                       }}>
                       {firstRound.status}
                     </td>
-                    <td style={{ width: TABLE_WIDTH[3] }}>{firstRoundTime}</td>
+                    <td style={{ width: TABLE_WIDTH[3] }}>{firstRoundDate}</td>
                     <td
                       style={{
                         width: TABLE_WIDTH[4],
@@ -122,7 +122,7 @@ function MemberDetail(props: Props) {
                       }}>
                       {secondRound.status}
                     </td>
-                    <td style={{ width: TABLE_WIDTH[5] }}>{secondRoundTime}</td>
+                    <td style={{ width: TABLE_WIDTH[5] }}>{secondRoundDate}</td>
                     <td
                       style={{
                         width: TABLE_WIDTH[6],

--- a/src/pages/attendanceAdmin/session/[id].tsx
+++ b/src/pages/attendanceAdmin/session/[id].tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import dayjs from 'dayjs';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -194,7 +195,12 @@ function SessionDetailPage() {
               const secondRound =
                 member.attendances.find((item) => item.round === 2) ??
                 attendanceInit;
-
+              const firstRoundTime = dayjs(firstRound.updateAt).format(
+                'YYYY/MM/DD HH:mm',
+              );
+              const secondRoundTime = dayjs(secondRound.updateAt).format(
+                'YYYY/MM/DD HH:mm',
+              );
               return (
                 <tr
                   key={member.member.memberId}
@@ -217,7 +223,7 @@ function SessionDetailPage() {
                       }
                     />
                   </td>
-                  <td className="member-date">{firstRound.updateAt}</td>
+                  <td className="member-date">{firstRoundTime}</td>
                   <td>
                     <Select
                       selected={secondRound.status}
@@ -231,7 +237,7 @@ function SessionDetailPage() {
                       }
                     />
                   </td>
-                  <td className="member-date">{secondRound.updateAt}</td>
+                  <td className="member-date">{secondRoundTime}</td>
                   <td>{addPlus(member.updatedScore)}점</td>
                   <td className="member-update">
                     {session.status === 'END' && isChangedMember(member) && (


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

- 서버측에서 보내온 ISO 8601 형식의 날짜 표기 방식을 뷰에 맞게 포맷을 변경합니다.

## ✅ PR Point

- `dayjs` 를 사용해서 작업하였습니다.
- `useDateformat` 이라는 커스텀 훅을 만들어서 사용하려고 했으나 `map()` 메서드 안에서 훅을 사용하게 되면 eslint 에 걸리게 됩니다. 그래서 사용하는 곳이 한정적이게 되는데, 그냥 커스텀 훅을 사용하지 말지, 아니면 좀더 추상화를 할 수 있는 방법이 있는지 궁금합니다.
