### PR TITLE
[#66][REFACTOR] 보라색 걷어내기 sprint0 ver.

### DIFF
--- a/src/components/attendanceAdmin/session/CreateSessionModal/style.ts
+++ b/src/components/attendanceAdmin/session/CreateSessionModal/style.ts
@@ -166,7 +166,7 @@ export const StDatePickerInput = styled.div<{ hasValue?: boolean }>`
           letter-spacing: -0.02em;
         }
         &:focus {
-          outline: ${({ theme }) => theme.color.main.purple100} solid 1px;
+          outline: ${({ theme }) => theme.color.grayscale.black40} solid 1px;
         }
       }
     }

--- a/src/components/orgAdmin/TextField/style.ts
+++ b/src/components/orgAdmin/TextField/style.ts
@@ -30,7 +30,7 @@ export const StTextField = styled.textarea<StyledTextAreaProps>`
   align-items: center;
 
   &:focus {
-    border: 1px solid ${({ theme }) => theme.color.main.purple100};
+    border: 1px solid ${({ theme }) => theme.color.grayscale.black40};
   }
 
   &::placeholder {


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

dev 에서 적용되지 않았던 보라색 걷어내기 작업 (DatePicker, 공홈 어드민) 부분에서의 보라색 컬러를 제거하였습니다.
