### PR TITLE
[#70][REFACTOR] 이전 기수에 대한 세션 생성/출석 기능 제한

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-hook-form": "^7.44.0",
     "react-query": "^3.39.3",
     "recoil": "^0.7.7",
+    "recoil-persist": "^5.1.0",
     "typescript": "5.0.2"
   },
   "devDependencies": {

--- a/src/components/attendanceAdmin/session/SessionList/index.tsx
+++ b/src/components/attendanceAdmin/session/SessionList/index.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 
+import ListActionButton from '@/components/common/ListActionButton';
 import ListWrapper from '@/components/common/ListWrapper';
 import Loading from '@/components/common/Loading';
 import Modal from '@/components/common/modal';
@@ -126,14 +127,13 @@ function SessionList() {
                 <td className="attendance">{absent}</td>
                 <td className="attendance">{unknown}</td>
                 <td>
-                  <span
-                    onClick={(event) => {
-                      event.stopPropagation();
+                  <ListActionButton
+                    text="조회"
+                    onClick={() => {
                       setSelectedLecture(lectureId);
                       setIsDetailOpen(true);
-                    }}>
-                    조회
-                  </span>
+                    }}
+                  />
                 </td>
               </tr>
             );

--- a/src/components/attendanceAdmin/session/SessionListFooter/index.tsx
+++ b/src/components/attendanceAdmin/session/SessionListFooter/index.tsx
@@ -1,4 +1,7 @@
+import { useRecoilValue } from 'recoil';
+
 import Button from '@/components/common/Button';
+import { currentGenerationState } from '@/recoil/atom';
 
 import { StFooterWrapper } from './style';
 
@@ -8,10 +11,16 @@ interface Props {
 
 function SessionListFooter(props: Props) {
   const { onClick } = props;
+  const currentGeneration = useRecoilValue(currentGenerationState);
 
   return (
     <StFooterWrapper>
-      <Button onClick={onClick} type={'submit'} text={'세션 생성하기'} />
+      <Button
+        onClick={onClick}
+        type={'submit'}
+        disabled={currentGeneration !== '33' && true}
+        text={'세션 생성하기'}
+      />
     </StFooterWrapper>
   );
 }

--- a/src/components/attendanceAdmin/totalScore/MemberList/index.tsx
+++ b/src/components/attendanceAdmin/totalScore/MemberList/index.tsx
@@ -1,6 +1,7 @@
 import { RefObject, useRef, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 
+import ListActionButton from '@/components/common/ListActionButton';
 import ListWrapper from '@/components/common/ListWrapper';
 import Loading from '@/components/common/Loading';
 import PartFilter from '@/components/common/PartFilter';
@@ -110,8 +111,11 @@ function MemberList() {
                     <td className="attendance">{tardy}</td>
                     <td className="attendance">{absent}</td>
                     <td className="attendance">{participate}</td>
-                    <td onClick={() => onChangeMember(member)}>
-                      <span>조회</span>
+                    <td>
+                      <ListActionButton
+                        text="조회"
+                        onClick={() => onChangeMember(member)}
+                      />
                     </td>
                   </tr>
                 );

--- a/src/components/common/ListActionButton/index.tsx
+++ b/src/components/common/ListActionButton/index.tsx
@@ -1,0 +1,26 @@
+import { StButton } from './style';
+
+interface Props {
+  text: string;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  disabled?: boolean;
+}
+
+function ListActionButton(props: Props) {
+  const { text, onClick, disabled = false } = props;
+
+  return (
+    <StButton
+      onClick={(e) => {
+        if (!disabled && onClick) {
+          e.stopPropagation();
+          onClick(e);
+        }
+      }}
+      disabled={disabled}>
+      {text}
+    </StButton>
+  );
+}
+
+export default ListActionButton;

--- a/src/components/common/ListActionButton/style.ts
+++ b/src/components/common/ListActionButton/style.ts
@@ -1,0 +1,27 @@
+import styled from '@emotion/styled';
+
+import { body2 } from '@/styles/fonts';
+
+export const StButton = styled.button`
+  ${body2}
+  transition: transform 0.1s;
+  display: inline-block;
+
+  padding: 0.6rem 1rem;
+  border: 0.1rem solid ${({ theme }) => theme.color.grayscale.gray60};
+  border-radius: 1.6rem;
+  background-color: ${({ theme }) => theme.color.grayscale.gray20};
+  color: ${({ theme }) => theme.color.grayscale.black40};
+
+  &:disabled {
+    background-color: ${({ theme }) => theme.color.grayscale.gray10};
+    border: 1px solid ${({ theme }) => theme.color.grayscale.gray20};
+    color: ${({ theme }) => theme.color.grayscale.gray30};
+    cursor: default;
+  }
+  cursor: pointer;
+  &:not(:disabled):hover {
+    transform: scale(1.15);
+    border-color: ${({ theme }) => theme.color.grayscale.gray100};
+  }
+`;

--- a/src/components/common/ListWrapper/style.ts
+++ b/src/components/common/ListWrapper/style.ts
@@ -47,23 +47,6 @@ export const StList = styled.table<{ tableWidth: string[] }>`
       border-bottom-right-radius: 1rem;
       border: 0.5px solid ${({ theme }) => theme.color.grayscale.gray30};
       border-left: none;
-
-      & > span {
-        transition: transform 0.1s;
-        display: inline-block;
-
-        padding: 0.5rem 0.9rem;
-        border: 0.1rem solid ${({ theme }) => theme.color.grayscale.gray60};
-        border-radius: 1.6rem;
-        background-color: ${({ theme }) => theme.color.grayscale.gray20};
-        color: ${({ theme }) => theme.color.grayscale.black40};
-
-        cursor: pointer;
-        &:hover {
-          transform: scale(1.15);
-          border-color: ${({ theme }) => theme.color.grayscale.gray100};
-        }
-      }
     }
   }
   .focused > td,

--- a/src/components/common/Nav/index.tsx
+++ b/src/components/common/Nav/index.tsx
@@ -31,6 +31,10 @@ function Nav() {
   const handleSelectedGeneration = (selectedGeneration: string) => {
     setCurrentGeneration(selectedGeneration);
     setIsDropdownOn(false);
+    const pathSegments = router.asPath.split('/');
+    if (pathSegments[pathSegments.length - 1].match(/^\d+$/)) {
+      router.push('/attendanceAdmin/session');
+    }
   };
 
   const handleSubMenuClick = (path: string) => {

--- a/src/components/common/Nav/index.tsx
+++ b/src/components/common/Nav/index.tsx
@@ -1,9 +1,8 @@
 import { useRouter } from 'next/router';
 import React, { useEffect, useRef, useState } from 'react';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { IcNavMenu } from '@/assets/icons';
-import { currentGenerationState } from '@/recoil/atom';
+import { useRecoilGenerationSSR } from '@/hooks/useRecoilGenerationSSR';
 import { MENU_LIST } from '@/utils/nav';
 
 import DropDown from '../DropDown';
@@ -20,10 +19,7 @@ const GENERATION_LIST = ['33', '32'];
 
 function Nav() {
   const router = useRouter();
-  const currentGeneration = useRecoilValue(currentGenerationState);
-  const setCurrentGeneration = useSetRecoilState<string>(
-    currentGenerationState,
-  );
+  const [currentGeneration, setCurrentGeneration] = useRecoilGenerationSSR();
   const [isDropdownOn, setIsDropdownOn] = useState<boolean>(false);
 
   const dropdownRef = useRef<HTMLDivElement | null>(null);

--- a/src/components/session/Select/index.tsx
+++ b/src/components/session/Select/index.tsx
@@ -1,7 +1,9 @@
 import { useTheme } from '@emotion/react';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useRecoilValue } from 'recoil';
 
 import IcDropdown from '@/components/icons/IcDropdown';
+import { currentGenerationState } from '@/recoil/atom';
 import { attendanceTranslator, getAttendanceColor } from '@/utils/translator';
 
 import { StOptions, StSelect, StSelectWrap } from './style';
@@ -20,6 +22,8 @@ function Select(props: Props) {
   const optionsRef = useRef<HTMLUListElement>(null);
 
   const [showOptions, setShowOptions] = useState(false);
+
+  const currentGeneration = useRecoilValue(currentGenerationState);
 
   const toggleOptions = useCallback(() => {
     setShowOptions(!showOptions);
@@ -49,9 +53,9 @@ function Select(props: Props) {
         <p style={{ color: getAttendanceColor(selected) }}>
           {attendanceTranslator[selected]}
         </p>
-        <IcDropdown />
+        {currentGeneration === '33' && <IcDropdown />}
       </StSelect>
-      {showOptions && (
+      {showOptions && currentGeneration === '33' && (
         <StOptions ref={optionsRef}>
           {options.map((option) => (
             <li key={option.value} onClick={() => onClickOption(option.value)}>

--- a/src/hooks/useRecoilGenerationSSR.ts
+++ b/src/hooks/useRecoilGenerationSSR.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+import { useRecoilState } from 'recoil';
+
+import { currentGenerationState } from '@/recoil/atom';
+
+export const useRecoilGenerationSSR = () => {
+  const defaultValue = '33';
+  const [isInitial, setIsInitial] = useState(true);
+  const [value, setValue] = useRecoilState(currentGenerationState);
+
+  useEffect(() => {
+    setIsInitial(false);
+  }, []);
+
+  return [isInitial ? defaultValue : value, setValue] as const;
+};

--- a/src/pages/attendanceAdmin/session/[id].tsx
+++ b/src/pages/attendanceAdmin/session/[id].tsx
@@ -228,6 +228,7 @@ function SessionDetailPage() {
                       <td>{addPlus(member.updatedScore)}점</td>
                       <td className="member-update">
                         <ListActionButton
+                          onClick={() => onUpdateScore(member.member.memberId)}
                           text="갱신"
                           disabled={
                             !(

--- a/src/pages/attendanceAdmin/session/[id].tsx
+++ b/src/pages/attendanceAdmin/session/[id].tsx
@@ -2,10 +2,12 @@ import styled from '@emotion/styled';
 import dayjs from 'dayjs';
 import { useRouter } from 'next/router';
 import { RefObject, useRef, useState } from 'react';
+import { useRecoilValue } from 'recoil';
 
 import AttendanceModal from '@/components/attendanceAdmin/session/AttendanceModal';
 import Button from '@/components/common/Button';
 import Footer from '@/components/common/Footer';
+import ListActionButton from '@/components/common/ListActionButton';
 import ListWrapper from '@/components/common/ListWrapper';
 import Loading from '@/components/common/Loading';
 import Modal from '@/components/common/modal';
@@ -14,6 +16,7 @@ import Select from '@/components/session/Select';
 import { PAGE_SIZE } from '@/data/queryData';
 import { attendanceInit, attendanceOptions } from '@/data/sessionData';
 import useObserver from '@/hooks/useObserver';
+import { currentGenerationState } from '@/recoil/atom';
 import {
   updateMemberAttendStatus,
   updateMemberScore,
@@ -47,6 +50,7 @@ function SessionDetailPage() {
   const [changedMembers, setChangedMembers] = useState<SessionMember[]>([]);
   const [modal, setModal] = useState<number | null>(null);
   const bottomRef: RefObject<HTMLDivElement> = useRef(null);
+  const currentGeneration = useRecoilValue(currentGenerationState);
 
   const {
     data: session,
@@ -223,15 +227,16 @@ function SessionDetailPage() {
                       <td className="member-date">{secondRoundTime}</td>
                       <td>{addPlus(member.updatedScore)}점</td>
                       <td className="member-update">
-                        {session.status === 'END' &&
-                          isChangedMember(member) && (
-                            <button
-                              onClick={() =>
-                                onUpdateScore(member.member.memberId)
-                              }>
-                              갱신
-                            </button>
-                          )}
+                        <ListActionButton
+                          text="갱신"
+                          disabled={
+                            !(
+                              session.status === 'END' &&
+                              isChangedMember(member) &&
+                              currentGeneration === '33'
+                            )
+                          }
+                        />
                       </td>
                     </tr>
                   );
@@ -304,15 +309,6 @@ const StPageWrapper = styled.div`
     }
     &-date {
       color: ${({ theme }) => theme.color.grayscale.gray80};
-    }
-    &-update button {
-      font-size: 1.2rem;
-      font-weight: 500;
-      padding: 0.6rem 1rem;
-      border: 1px solid ${({ theme }) => theme.color.grayscale.gray60};
-      border-radius: 16px;
-      background-color: ${({ theme }) => theme.color.grayscale.gray20};
-      color: ${({ theme }) => theme.color.grayscale.black40};
     }
   }
   .empty {

--- a/src/recoil/atom.ts
+++ b/src/recoil/atom.ts
@@ -1,6 +1,16 @@
 import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+
+const sessionStorage =
+  typeof window !== 'undefined' ? window.sessionStorage : undefined;
+
+const { persistAtom } = recoilPersist({
+  key: 'generationStorage',
+  storage: sessionStorage,
+});
 
 export const currentGenerationState = atom<string>({
   key: 'currentGenerationState',
   default: '33',
+  effects_UNSTABLE: [persistAtom],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8793,6 +8793,11 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
+recoil-persist@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/recoil-persist/-/recoil-persist-5.1.0.tgz#c4232fe04f2e4b6afcc815baff56f2521f6dcde1"
+  integrity sha512-sew4k3uBVJjRWKCSFuBw07Y1p1pBOb0UxLJPxn4G2bX/9xNj+r2xlqYy/BRfyofR/ANfqBU04MIvulppU4ZC0w==
+
 recoil@^0.7.7:
   version "0.7.7"
   resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.7.7.tgz#c5f2c843224384c9c09e4a62c060fb4c1454dc8e"


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

Closes #70 

## ✨ 구현 기능 명세

- 현재 활동중인 기수를 제외한 나머지 기수에서 세션생성, 출석 개별갱신을 불가능하도록 설정했습니다.
- 출석 개별갱신 버튼이 `disabled` 일 경우 `display:none` 이 되는 것이 아닌 `disabled` 에 해당하는 스타일링이 적용되도록 변경했습니다.
- 세션목록, 세션상세, 출석총점 탭에서 공통적으로 사용되는 `관리`, `조회`, `갱신`  버튼을 `ListActionButton` 이라는 이름의 컴포넌트로 추상화하였습니다.

## ✅ PR Point

- Nav의 기수 드롭다운에서 결정되는 atom 값을 이용해 각 컴포넌트에서 기능 비활성화 여부를 결정했는데, 여러 컴포넌트에 useRecoilValue 의 사용과 조건을 넣어주는것이 번거로워 이 기수판별 로직을 담당하는 커스텀 훅을 만드는게 어떨까 고민중에 있습니다.
왜냐하면 나중에 34기로 기수를 변경한다고 치면 하드코딩된 부분을 모두 변경해줘야 하기때문에...

## 😭 어려웠던 점

조건부.. 렌더링..
