### PR TITLE
fix : 리프레시 토큰 요청에 대한 400 에러 리디렉션

### DIFF
--- a/src/services/api/auth/index.ts
+++ b/src/services/api/auth/index.ts
@@ -31,6 +31,12 @@ export const reissueAccessToken = async (): Promise<void | LoginError> => {
   try {
     const { data }: AxiosResponse<{ data: string }> = await client.patch(
       '/auth/refresh',
+      {},
+      {
+        headers: {
+          'Reissue-Request': 'true',
+        },
+      },
     );
     const accessToken = data.data;
     setToken('ACCESS', accessToken);

--- a/src/services/api/client.ts
+++ b/src/services/api/client.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosError, AxiosInstance, AxiosRequestConfig } from 'axios';
 
 import config from '@/configs/config';
-import { getAuthHeader, getToken } from '@/utils/auth';
+import { destroyToken, getAuthHeader, getToken } from '@/utils/auth';
 
 import { reissueAccessToken } from './auth';
 
@@ -55,6 +55,10 @@ client.interceptors.response.use(
     if (error.response) {
       switch (error.response.status) {
         case 400:
+          if (error?.config?.headers['Reissue-Request']) {
+            destroyToken('ACCESS');
+            window.location.replace('/');
+          }
           return { status: 400, error: '요청을 처리하는데 실패했어요' };
         case 401:
           await reissueAccessToken();


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

- 엑세스 토큰 만료시(`400`) 로그인 화면으로 리디렉션 되도록 하였습니다.

## 😭 어려웠던 점

- 인터셉터의 재귀호출.. 꼭 막아야합니다..