### PR TITLE
[#75][REFACTOR] 출석 관련 로직 비활성화, 서버측 데이터로 제어

### DIFF
--- a/src/components/attendanceAdmin/session/SessionList/SessionDetailModal/index.tsx
+++ b/src/components/attendanceAdmin/session/SessionList/SessionDetailModal/index.tsx
@@ -1,10 +1,9 @@
 import { IcCheckBox, IcModalClose } from '@/assets/icons';
 import Button from '@/components/common/Button';
 import InputContainer from '@/components/common/inputContainer';
-import Loading from '@/components/common/Loading';
-import { useDateFormat } from '@/hooks/useDateFormat';
 import { deleteSession } from '@/services/api/lecture';
 import { useGetLectureDetail } from '@/services/api/lecture/query';
+import { transDate } from '@/utils/date';
 
 import {
   StFooter,
@@ -23,9 +22,9 @@ const SessionDetailModal = (props: Props) => {
   const { onClose, lectureId } = props;
   const { data } = useGetLectureDetail(lectureId);
 
-  const date = useDateFormat(data?.startDate, 'date');
-  const startTime = useDateFormat(data?.startDate, 'time');
-  const endTime = useDateFormat(data?.endDate, 'time');
+  const date = transDate(data?.startDate, 'date');
+  const startTime = transDate(data?.startDate, 'time');
+  const endTime = transDate(data?.endDate, 'time');
 
   const handleDeleteSession = () => {
     const isConfirmed = confirm(

--- a/src/components/attendanceAdmin/session/SessionListFooter/index.tsx
+++ b/src/components/attendanceAdmin/session/SessionListFooter/index.tsx
@@ -19,7 +19,7 @@ function SessionListFooter(props: Props) {
       <Button
         onClick={onClick}
         type={'submit'}
-        disabled={currentGeneration !== ACTIVITY_GENRATION ? true : false}
+        disabled={currentGeneration !== ACTIVITY_GENRATION}
         text={'세션 생성하기'}
       />
     </StFooterWrapper>

--- a/src/components/attendanceAdmin/session/SessionListFooter/index.tsx
+++ b/src/components/attendanceAdmin/session/SessionListFooter/index.tsx
@@ -2,6 +2,7 @@ import { useRecoilValue } from 'recoil';
 
 import Button from '@/components/common/Button';
 import { currentGenerationState } from '@/recoil/atom';
+import { activityGeneration } from '@/utils/activityGeneration';
 
 import { StFooterWrapper } from './style';
 
@@ -18,7 +19,7 @@ function SessionListFooter(props: Props) {
       <Button
         onClick={onClick}
         type={'submit'}
-        disabled={currentGeneration !== '33' && true}
+        disabled={currentGeneration !== activityGeneration ? true : false}
         text={'세션 생성하기'}
       />
     </StFooterWrapper>

--- a/src/components/attendanceAdmin/session/SessionListFooter/index.tsx
+++ b/src/components/attendanceAdmin/session/SessionListFooter/index.tsx
@@ -2,7 +2,7 @@ import { useRecoilValue } from 'recoil';
 
 import Button from '@/components/common/Button';
 import { currentGenerationState } from '@/recoil/atom';
-import { activityGeneration } from '@/utils/activityGeneration';
+import { ACTIVITY_GENRATION } from '@/utils/generation';
 
 import { StFooterWrapper } from './style';
 
@@ -19,7 +19,7 @@ function SessionListFooter(props: Props) {
       <Button
         onClick={onClick}
         type={'submit'}
-        disabled={currentGeneration !== activityGeneration ? true : false}
+        disabled={currentGeneration !== ACTIVITY_GENRATION ? true : false}
         text={'세션 생성하기'}
       />
     </StFooterWrapper>

--- a/src/components/common/Nav/index.tsx
+++ b/src/components/common/Nav/index.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import { IcNavMenu } from '@/assets/icons';
 import { useRecoilGenerationSSR } from '@/hooks/useRecoilGenerationSSR';
+import { GENERATION_LIST } from '@/utils/generation';
 import { MENU_LIST } from '@/utils/nav';
 
 import DropDown from '../DropDown';
@@ -14,8 +15,6 @@ import {
   StSoptLogo,
   StSubMenu,
 } from './style';
-
-const GENERATION_LIST = ['33', '32'];
 
 function Nav() {
   const router = useRouter();

--- a/src/components/session/Select/index.tsx
+++ b/src/components/session/Select/index.tsx
@@ -1,9 +1,8 @@
 import { useTheme } from '@emotion/react';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useRecoilValue } from 'recoil';
 
 import IcDropdown from '@/components/icons/IcDropdown';
-import { currentGenerationState } from '@/recoil/atom';
+import { activityGeneration } from '@/utils/activityGeneration';
 import { attendanceTranslator, getAttendanceColor } from '@/utils/translator';
 
 import { StOptions, StSelect, StSelectWrap } from './style';
@@ -11,19 +10,16 @@ import { StOptions, StSelect, StSelectWrap } from './style';
 interface Props {
   options: Array<{ label: string; value: ATTEND_STATUS }>;
   selected: ATTEND_STATUS;
+  generation: string;
   onChange: (value: ATTEND_STATUS) => void;
 }
 
 function Select(props: Props) {
-  const { options, selected, onChange } = props;
-
-  const theme = useTheme();
+  const { options, selected, generation, onChange } = props;
 
   const optionsRef = useRef<HTMLUListElement>(null);
 
   const [showOptions, setShowOptions] = useState(false);
-
-  const currentGeneration = useRecoilValue(currentGenerationState);
 
   const toggleOptions = useCallback(() => {
     setShowOptions(!showOptions);
@@ -53,9 +49,9 @@ function Select(props: Props) {
         <p style={{ color: getAttendanceColor(selected) }}>
           {attendanceTranslator[selected]}
         </p>
-        {currentGeneration === '33' && <IcDropdown />}
+        {generation === activityGeneration && <IcDropdown />}
       </StSelect>
-      {showOptions && currentGeneration === '33' && (
+      {showOptions && generation === activityGeneration && (
         <StOptions ref={optionsRef}>
           {options.map((option) => (
             <li key={option.value} onClick={() => onClickOption(option.value)}>

--- a/src/components/session/Select/index.tsx
+++ b/src/components/session/Select/index.tsx
@@ -2,7 +2,7 @@ import { useTheme } from '@emotion/react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import IcDropdown from '@/components/icons/IcDropdown';
-import { activityGeneration } from '@/utils/activityGeneration';
+import { ACTIVITY_GENRATION } from '@/utils/generation';
 import { attendanceTranslator, getAttendanceColor } from '@/utils/translator';
 
 import { StOptions, StSelect, StSelectWrap } from './style';
@@ -49,9 +49,9 @@ function Select(props: Props) {
         <p style={{ color: getAttendanceColor(selected) }}>
           {attendanceTranslator[selected]}
         </p>
-        {generation === activityGeneration && <IcDropdown />}
+        {generation === ACTIVITY_GENRATION && <IcDropdown />}
       </StSelect>
-      {showOptions && generation === activityGeneration && (
+      {showOptions && generation === ACTIVITY_GENRATION && (
         <StOptions ref={optionsRef}>
           {options.map((option) => (
             <li key={option.value} onClick={() => onClickOption(option.value)}>

--- a/src/hooks/useRecoilGenerationSSR.ts
+++ b/src/hooks/useRecoilGenerationSSR.ts
@@ -2,9 +2,9 @@ import { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
 
 import { currentGenerationState } from '@/recoil/atom';
+import { activityGeneration } from '@/utils/activityGeneration';
 
 export const useRecoilGenerationSSR = () => {
-  const defaultValue = '33';
   const [isInitial, setIsInitial] = useState(true);
   const [value, setValue] = useRecoilState(currentGenerationState);
 
@@ -12,5 +12,5 @@ export const useRecoilGenerationSSR = () => {
     setIsInitial(false);
   }, []);
 
-  return [isInitial ? defaultValue : value, setValue] as const;
+  return [isInitial ? activityGeneration : value, setValue] as const;
 };

--- a/src/hooks/useRecoilGenerationSSR.ts
+++ b/src/hooks/useRecoilGenerationSSR.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
 
 import { currentGenerationState } from '@/recoil/atom';
-import { activityGeneration } from '@/utils/activityGeneration';
+import { ACTIVITY_GENRATION } from '@/utils/generation';
 
 export const useRecoilGenerationSSR = () => {
   const [isInitial, setIsInitial] = useState(true);
@@ -12,5 +12,5 @@ export const useRecoilGenerationSSR = () => {
     setIsInitial(false);
   }, []);
 
-  return [isInitial ? activityGeneration : value, setValue] as const;
+  return [isInitial ? ACTIVITY_GENRATION : value, setValue] as const;
 };

--- a/src/pages/attendanceAdmin/session/[id].tsx
+++ b/src/pages/attendanceAdmin/session/[id].tsx
@@ -26,7 +26,7 @@ import {
   useGetSessionDetail,
 } from '@/services/api/lecture/query';
 import { addPlus, precision } from '@/utils';
-import { activityGeneration } from '@/utils/activityGeneration';
+import { ACTIVITY_GENRATION } from '@/utils/generation';
 
 const HEADER_LABELS = [
   '순번',
@@ -235,7 +235,7 @@ function SessionDetailPage() {
                             !(
                               session.status === 'END' &&
                               isChangedMember(member) &&
-                              String(session.generation) === activityGeneration
+                              String(session.generation) === ACTIVITY_GENRATION
                             )
                           }
                         />

--- a/src/pages/attendanceAdmin/session/[id].tsx
+++ b/src/pages/attendanceAdmin/session/[id].tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 import dayjs from 'dayjs';
 import { useRouter } from 'next/router';
 import { RefObject, useRef, useState } from 'react';
-import { useRecoilValue } from 'recoil';
 
 import AttendanceModal from '@/components/attendanceAdmin/session/AttendanceModal';
 import Button from '@/components/common/Button';
@@ -17,7 +16,6 @@ import Select from '@/components/session/Select';
 import { PAGE_SIZE } from '@/data/queryData';
 import { attendanceInit, attendanceOptions } from '@/data/sessionData';
 import useObserver from '@/hooks/useObserver';
-import { currentGenerationState } from '@/recoil/atom';
 import {
   updateMemberAttendStatus,
   updateMemberScore,
@@ -28,6 +26,7 @@ import {
   useGetSessionDetail,
 } from '@/services/api/lecture/query';
 import { addPlus, precision } from '@/utils';
+import { activityGeneration } from '@/utils/activityGeneration';
 
 const HEADER_LABELS = [
   '순번',
@@ -51,7 +50,6 @@ function SessionDetailPage() {
   const [changedMembers, setChangedMembers] = useState<SessionMember[]>([]);
   const [modal, setModal] = useState<number | null>(null);
   const bottomRef: RefObject<HTMLDivElement> = useRef(null);
-  const currentGeneration = useRecoilValue(currentGenerationState);
 
   const {
     data: session,
@@ -209,6 +207,7 @@ function SessionDetailPage() {
                               firstRound.subAttendanceId,
                             )
                           }
+                          generation={String(session.generation)}
                         />
                       </td>
                       <td className="member-date">{firstRoundTime}</td>
@@ -223,6 +222,7 @@ function SessionDetailPage() {
                               secondRound.subAttendanceId,
                             )
                           }
+                          generation={String(session.generation)}
                         />
                       </td>
                       <td className="member-date">{secondRoundTime}</td>
@@ -235,7 +235,7 @@ function SessionDetailPage() {
                             !(
                               session.status === 'END' &&
                               isChangedMember(member) &&
-                              currentGeneration === '33'
+                              String(session.generation) === activityGeneration
                             )
                           }
                         />

--- a/src/utils/activityGeneration.ts
+++ b/src/utils/activityGeneration.ts
@@ -1,1 +1,0 @@
-export const activityGeneration: string = '33';

--- a/src/utils/activityGeneration.ts
+++ b/src/utils/activityGeneration.ts
@@ -1,0 +1,1 @@
+export const activityGeneration: string = '33';

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -2,7 +2,7 @@ import dayjs from 'dayjs';
 
 type FormatType = 'date' | 'time';
 
-export const useDateFormat = (
+export const transDate = (
   date: string | undefined,
   type: FormatType,
 ): string => {

--- a/src/utils/generation.ts
+++ b/src/utils/generation.ts
@@ -1,0 +1,1 @@
+export const ACTIVITY_GENRATION: string = '33';

--- a/src/utils/generation.ts
+++ b/src/utils/generation.ts
@@ -1,1 +1,3 @@
 export const ACTIVITY_GENRATION: string = '33';
+
+export const GENERATION_LIST: string[] = ['33', '32'];


### PR DESCRIPTION
Closes #75 

## ✨ 구현 기능 명세

- 기존 recoil atom 값을 통해 관리되던 이전기수에 대한 비활성화 로직을 서버에서 받아온 값으로 처리하도록 변경했습니다.
- 각종 조건부 렌더링에 '33' 으로 하드코딩 되어있던 활동기수 값을 `activityGeneration` 이라는 값으로 저장하여 추후 관리하기 쉽도록 변경했습니다.
- hook 이 포함되어 있지 않았지만 hook 으로 분류되었던 `useDateFormat` 함수를 `transDate` 라는 일반함수로 변경하고 `utils/date` 디렉토리로 이동시켰습니다.

## ✅ PR Point

코드보고 혹시 아직 하드코딩 되어있는 부분 있으면 알려주세요..!!