### PR TITLE
[REFACTOR] 세션 삭제 로직 변경

### DIFF
--- a/src/components/attendanceAdmin/session/SessionList/index.tsx
+++ b/src/components/attendanceAdmin/session/SessionList/index.tsx
@@ -9,19 +9,13 @@ import IcPlace from '@/assets/icons/IcPlace.svg';
 import Chip from '@/components/common/Chip';
 import ListWrapper from '@/components/common/ListWrapper';
 import Loading from '@/components/common/Loading';
-import Modal from '@/components/common/modal';
 import PartFilter from '@/components/common/PartFilter';
 import { currentGenerationState } from '@/recoil/atom';
+import { deleteSession } from '@/services/api/lecture';
 import { useGetSessionList } from '@/services/api/lecture/query';
 import { partTranslator } from '@/utils/translator';
 
-import SessionDetailModal from './SessionDetailModal';
-import {
-  StActionButton,
-  StListHeader,
-  StListItem,
-  StSessionName,
-} from './style';
+import { StActionButton, StListHeader, StListItem } from './style';
 
 function SessionList() {
   const router = useRouter();
@@ -52,6 +46,16 @@ function SessionList() {
 
   const onChangePart = (part: PART) => {
     setSelectedPart(part);
+  };
+
+  const handleDeleteSession = (lectureId: number) => {
+    const isConfirmed = confirm(
+      '세션을 삭제하면 복구할 수 없습니다.\n정말 삭제할까요?',
+    );
+    if (isConfirmed) {
+      deleteSession(lectureId);
+      alert('세션이 삭제되었습니다.');
+    }
   };
 
   return (
@@ -112,27 +116,25 @@ function SessionList() {
                     장소
                   </p>
                 </div>
-                <StActionButton
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setSelectedLecture(lectureId);
-                    setIsDetailOpen(true);
-                  }}>
-                  <IcMore />
-                </StActionButton>
+                <div>
+                  <StActionButton
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setSelectedLecture(lectureId);
+                      setIsDetailOpen(true);
+                      console.log('눌렸습니다.');
+                    }}>
+                    <IcMore />
+                  </StActionButton>
+                  <div className="delete_dropdown">
+                    <p>삭제하기</p>
+                  </div>
+                </div>
               </div>
             </StListItem>
           );
         })}
       </ListWrapper>
-      {isDetailOpen && (
-        <Modal>
-          <SessionDetailModal
-            onClose={() => setIsDetailOpen(!isDetailOpen)}
-            lectureId={selectedLecture}
-          />
-        </Modal>
-      )}
       {isLoading && <Loading />}
     </>
   );

--- a/src/components/attendanceAdmin/session/SessionList/index.tsx
+++ b/src/components/attendanceAdmin/session/SessionList/index.tsx
@@ -25,6 +25,7 @@ function SessionList() {
   const [isDetailOpen, setIsDetailOpen] = useState<Boolean>(false);
   const [selectedLecture, setSelectedLecture] = useState<number>(0);
   const currentGeneration = useRecoilValue(currentGenerationState);
+  const [activeDropdownId, setActiveDropdownId] = useState<number | null>(null);
 
   const { data, isLoading, isError, error } = useGetSessionList(
     parseInt(currentGeneration),
@@ -46,6 +47,15 @@ function SessionList() {
 
   const onChangePart = (part: PART) => {
     setSelectedPart(part);
+  };
+
+  const toggleDropdown = (e: any, lectureId: number) => {
+    e.stopPropagation();
+    if (activeDropdownId === lectureId) {
+      setActiveDropdownId(null);
+    } else {
+      setActiveDropdownId(lectureId);
+    }
   };
 
   const handleDeleteSession = (lectureId: number) => {
@@ -117,18 +127,16 @@ function SessionList() {
                   </p>
                 </div>
                 <div>
-                  <StActionButton
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setSelectedLecture(lectureId);
-                      setIsDetailOpen(true);
-                      console.log('눌렸습니다.');
-                    }}>
+                  <StActionButton onClick={(e) => toggleDropdown(e, lectureId)}>
                     <IcMore />
                   </StActionButton>
-                  <div className="delete_dropdown">
-                    <p>삭제하기</p>
-                  </div>
+                  {activeDropdownId === lectureId && (
+                    <div
+                      className="delete_dropdown"
+                      onClick={() => handleDeleteSession(lectureId)}>
+                      <p>삭제하기</p>
+                    </div>
+                  )}
                 </div>
               </div>
             </StListItem>

--- a/src/components/attendanceAdmin/session/SessionList/index.tsx
+++ b/src/components/attendanceAdmin/session/SessionList/index.tsx
@@ -41,15 +41,15 @@ function SessionList() {
     }
   }, [data, error, isError, router]);
 
-  const handleManageClick = (lectureId: number) => {
+  const handleManageClick = (lectureId: number): void => {
     router.push(`/attendanceAdmin/session/${lectureId}`);
   };
 
-  const onChangePart = (part: PART) => {
+  const onChangePart = (part: PART): void => {
     setSelectedPart(part);
   };
 
-  const toggleDropdown = (e: any, lectureId: number) => {
+  const toggleDropdown = (e: React.MouseEvent, lectureId: number): void => {
     e.stopPropagation();
     if (activeDropdownId === lectureId) {
       setActiveDropdownId(null);
@@ -58,7 +58,11 @@ function SessionList() {
     }
   };
 
-  const handleDeleteSession = (lectureId: number) => {
+  const handleDeleteSession = (
+    e: React.MouseEvent<HTMLDivElement>,
+    lectureId: number,
+  ): void => {
+    e.stopPropagation();
     const isConfirmed = confirm(
       '세션을 삭제하면 복구할 수 없습니다.\n정말 삭제할까요?',
     );
@@ -76,7 +80,7 @@ function SessionList() {
         <p>총 {lectureData.length}개</p>
       </StListHeader>
       <ListWrapper>
-        {lectureData?.map((lecture, index) => {
+        {lectureData?.map((lecture) => {
           const {
             lectureId,
             partValue,
@@ -133,7 +137,7 @@ function SessionList() {
                   {activeDropdownId === lectureId && (
                     <div
                       className="delete_dropdown"
-                      onClick={() => handleDeleteSession(lectureId)}>
+                      onClick={(e) => handleDeleteSession(e, lectureId)}>
                       <p>삭제하기</p>
                     </div>
                   )}

--- a/src/components/attendanceAdmin/session/SessionList/style.ts
+++ b/src/components/attendanceAdmin/session/SessionList/style.ts
@@ -65,6 +65,42 @@ export const StListItem = styled.li`
         gap: 8px;
       }
     }
+
+    & > div:last-of-type {
+      display: flex;
+      flex-direction: column;
+
+      & > div.delete_dropdown {
+        position: absolute;
+
+        display: flex;
+        justify-content: flex-start;
+        align-items: center;
+
+        width: 9.3rem;
+
+        margin-top: 1rem;
+        padding: 0.8rem 0.7rem;
+
+        background-color: ${colors.gray700};
+        border-radius: 1rem;
+
+        & > p {
+          width: 100%;
+          height: 100%;
+
+          padding: 0.5rem 0.9rem;
+
+          color: ${colors.error};
+
+          border-radius: 0.6rem;
+
+          &:hover {
+            background-color: ${colors.gray600};
+          }
+        }
+      }
+    }
   }
 `;
 
@@ -77,6 +113,8 @@ export const StSessionName = styled.p`
 `;
 
 export const StActionButton = styled.button`
+  position: relative;
+
   width: 32px;
   height: 32px;
   border-radius: 8px;

--- a/src/components/attendanceAdmin/session/SessionList/style.ts
+++ b/src/components/attendanceAdmin/session/SessionList/style.ts
@@ -69,9 +69,12 @@ export const StListItem = styled.li`
     & > div:last-of-type {
       display: flex;
       flex-direction: column;
+      position: relative;
 
       & > div.delete_dropdown {
         position: absolute;
+        top: 100%;
+        right: 0.001%; // 요소의 왼쪽 경계를 부모의 중앙에 위치시킵니다.
 
         display: flex;
         justify-content: flex-start;
@@ -85,6 +88,8 @@ export const StListItem = styled.li`
         background-color: ${colors.gray700};
         border-radius: 1rem;
 
+        animation: appearDropdown 0.6s;
+
         & > p {
           width: 100%;
           height: 100%;
@@ -97,6 +102,17 @@ export const StListItem = styled.li`
 
           &:hover {
             background-color: ${colors.gray600};
+          }
+        }
+
+        @keyframes appearDropdown {
+          from {
+            opacity: 0;
+            transform: translateY(-1rem);
+          }
+          to {
+            opacity: 1;
+            transform: translateY(0rem);
           }
         }
       }


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

- 기존의 세션 상세 모달에서 진행하던 세션 삭제 작업을 리스트의 IcMore 를 클릭하면 작동할 수 있도록 작업했습니다.
- 기존의 세션 상세 모달은 일단 필요하지 않을 것으로 생각되는데, pm pd 와 논의가 필요할 것 같습니다.
