### PR TITLE
[#94][REFACTOR] 세션 상세 정보(세션 날짜, 장소) 새로운 리스트에 반영

### DIFF
--- a/src/components/attendanceAdmin/session/SessionList/index.tsx
+++ b/src/components/attendanceAdmin/session/SessionList/index.tsx
@@ -13,6 +13,7 @@ import PartFilter from '@/components/common/PartFilter';
 import { currentGenerationState } from '@/recoil/atom';
 import { deleteSession } from '@/services/api/lecture';
 import { useGetSessionList } from '@/services/api/lecture/query';
+import { transDate } from '@/utils/date';
 import { partTranslator } from '@/utils/translator';
 
 import { StActionButton, StListHeader, StListItem } from './style';
@@ -87,12 +88,15 @@ function SessionList() {
             attributeName,
             name,
             startDate,
+            endDate,
+            place,
             attendances,
           } = lecture;
           const { attendance, tardy, absent, unknown } = attendances;
           const part = partTranslator[partValue] || partValue;
-          const date = dayjs(startDate);
-          const formattedDate = date.format('YYYY년 MM월 DD일 HH:mm');
+          const date = dayjs(startDate).format('YYYY년 MM월 DD일');
+          const startTime = transDate(startDate, 'time');
+          const endTime = transDate(endDate, 'time');
 
           return (
             <StListItem
@@ -123,11 +127,11 @@ function SessionList() {
                 <div>
                   <p>
                     <IcDate />
-                    {formattedDate}
+                    {date} {startTime} - {endTime}
                   </p>
                   <p>
                     <IcPlace />
-                    장소
+                    {place}
                   </p>
                 </div>
                 <div>

--- a/src/components/attendanceAdmin/session/SessionList/style.ts
+++ b/src/components/attendanceAdmin/session/SessionList/style.ts
@@ -51,7 +51,7 @@ export const StListItem = styled.li`
   .right {
     ${fonts.BODY_14_M}
     display: flex;
-    align-items: flex-start;
+    align-items: center;
     gap: 55px;
 
     & > div:first-of-type {

--- a/src/components/attendanceAdmin/session/SessionList/style.ts
+++ b/src/components/attendanceAdmin/session/SessionList/style.ts
@@ -51,13 +51,15 @@ export const StListItem = styled.li`
   .right {
     ${fonts.BODY_14_M}
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: 55px;
 
     & > div:first-of-type {
       display: flex;
       flex-direction: column;
       gap: 4px;
+
+      width: 22rem;
 
       p {
         display: flex;

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -87,6 +87,8 @@ declare global {
     partValue: PART;
     partName: string;
     startDate: string; // yyyy/MM/dd
+    endDate: string;
+    place: string;
     attributeValue: SESSION_TYPE;
     attributeName: string;
     attendances: {


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

Closes #94 

## ✨ 구현 기능 명세

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

- 기존의 상세 모달에 존재하던 세션 날짜와 장소를 새로운 디자인으로 변경된 리스트에 반영했습니다.
- sessionList interface 의 필드를 새로운 API 명세에 맞게 수정했습니다.
