### PR TITLE
[REFACTOR]: 순수 onClose prop 추가, session, member resetchOnReconnect 옵션 추가

### DIFF
--- a/src/components/attendanceAdmin/session/AttendanceModal/index.tsx
+++ b/src/components/attendanceAdmin/session/AttendanceModal/index.tsx
@@ -15,13 +15,14 @@ interface Props {
   round: number;
   lectureId: number;
   finishAttendance: () => void;
+  onClose: () => void;
 }
 
 const MINUTES = 10;
 const SECONDS = 0;
 
 function AttendanceModal(props: Props) {
-  const { round, lectureId, finishAttendance } = props;
+  const { round, lectureId, finishAttendance, onClose } = props;
 
   const [timer, setTimer] = useState({ minutes: MINUTES, seconds: SECONDS });
   const [code, setCode] = useState('');
@@ -46,12 +47,12 @@ function AttendanceModal(props: Props) {
         if (isRetry) {
           start();
         } else {
-          finishAttendance();
+          onClose();
         }
       }
     };
     start();
-  }, [lectureId, round, finishAttendance]);
+  }, [lectureId, round, onClose]);
 
   useEffect(() => {
     if (status !== 'STARTED') return;

--- a/src/pages/attendanceAdmin/session/[id].tsx
+++ b/src/pages/attendanceAdmin/session/[id].tsx
@@ -392,6 +392,7 @@ function SessionDetailPage() {
             round={modal}
             lectureId={session.lectureId}
             finishAttendance={finishAttendance}
+            onClose={() => setModal(null)}
           />
         </Modal>
       )}

--- a/src/services/api/lecture/query.ts
+++ b/src/services/api/lecture/query.ts
@@ -33,7 +33,7 @@ export const useGetSessionDetail = (lectureId: number | null) => {
   return useQuery<SessionDetail | null, Error>(
     ['sessionDetail', lectureId],
     () => (lectureId ? getSessionDetail(lectureId) : null),
-    { staleTime: 10 * 60 * 1000 },
+    { staleTime: 10 * 60 * 1000, refetchOnReconnect: false },
   );
 };
 
@@ -54,6 +54,7 @@ export const useGetInfiniteSessionMembers = (
         lastPage && lastPage.attendances.length < PAGE_SIZE
           ? null
           : pages.length,
+      refetchOnReconnect: false,
     },
   );
 };


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

- [해당 이슈](https://sopt-makers.slack.com/archives/C06KS9ATSG1/p1724484388577249)의 문제를 해결하기 위해 출석 시작을 담당하는 useEffect에서 refetch를 유발하는 dependency인 finishAttendance를 제거합니다.
   - 순수하게 모달을 닫는 함수를 전달할 수 있는 onClose prop을 생성합니다.
- 멤버, 세션 정보를 불러오는 Query의 refetchOnReconnect 옵션을 false 로 설정하여 네트워크 변동에 출석 모달이 영향받지 않도록 수정합니다.

## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

- 해당 대응은 당장의 문제를 해결할 수 있지만, 최고의 해결책은 아니라고 생각합니다. 로직과 뷰를 분리하는 리팩토링이 필요해 보입니다.

### AS-IS
https://github.com/user-attachments/assets/66445f2f-d51c-4043-95db-75c05144459c


### TO-BE
https://github.com/user-attachments/assets/4294e5de-bfb6-4b63-93b3-bafcfc2a48f6


