### PR TITLE
[FEATURE] 소개탭, 지원하기탭 필수조건 에러처리 및 label 수정

### DIFF
--- a/src/components/org/OrgAdmin/AboutSection/CoreValue/index.tsx
+++ b/src/components/org/OrgAdmin/AboutSection/CoreValue/index.tsx
@@ -1,5 +1,7 @@
 import { useFormContext } from 'react-hook-form';
 
+import { VALIDATION_CHECK } from '@/utils/org';
+
 import MyDropzone from '../../MyDropzone';
 import {
   StDescription,
@@ -12,7 +14,10 @@ import { StInputBox, StInputWrapper, StValueWrapper } from './style';
 
 const CoreValue = () => {
   const method = useFormContext();
-  const { register } = method;
+  const {
+    register,
+    formState: { errors },
+  } = method;
   return (
     <StWrapper>
       <StTitle>핵심 가치</StTitle>
@@ -22,18 +27,26 @@ const CoreValue = () => {
         <StInputWrapper>
           <MyDropzone
             method={method}
-            label={'coreValue.0.imageFileName'}
+            label={'coreValue1_imageFileName'}
             width="224px"
             height="190px"
           />
           <StInputBox>
             <StInput
-              {...register('coreValue.0.value')}
+              {...register('coreValue1_value', {
+                required: true && VALIDATION_CHECK.required.errorText,
+              })}
+              isError={errors.coreValue1_value?.message !== undefined}
+              errorMessage={errors.coreValue1_value?.message as string}
               labelText="가치"
               placeholder="ex. 용기"
             />
             <StInput
-              {...register('coreValue.0.description')}
+              {...register('coreValue1_description', {
+                required: true && VALIDATION_CHECK.required.errorText,
+              })}
+              isError={errors.coreValue1_description?.message !== undefined}
+              errorMessage={errors.coreValue1_description?.message as string}
               labelText="가치 설명"
               descriptionText="호버 시, 보이는 문구예요."
               placeholder="ex. 새로운 도전을 위해 과감히 용기내는 사람"
@@ -47,18 +60,26 @@ const CoreValue = () => {
         <StInputWrapper>
           <MyDropzone
             method={method}
-            label={'coreValue.1.imageFileName'}
+            label={'coreValue2_imageFileName'}
             width="224px"
             height="190px"
           />
           <StInputBox>
             <StInput
-              {...register('coreValue.1.value')}
+              {...register('coreValue2_value', {
+                required: true && VALIDATION_CHECK.required.errorText,
+              })}
+              isError={errors.coreValue2_value?.message !== undefined}
+              errorMessage={errors.coreValue2_value?.message as string}
               labelText="가치"
               placeholder="ex. 몰입"
             />
             <StInput
-              {...register('coreValue.1.description')}
+              {...register('coreValue2_description', {
+                required: true && VALIDATION_CHECK.required.errorText,
+              })}
+              isError={errors.coreValue2_description?.message !== undefined}
+              errorMessage={errors.coreValue2_description?.message as string}
               labelText="가치 설명"
               descriptionText="호버 시, 보이는 문구예요."
               placeholder="ex. 포기하지 않고 깊이 몰입하는 사람"
@@ -72,18 +93,26 @@ const CoreValue = () => {
         <StInputWrapper>
           <MyDropzone
             method={method}
-            label={'coreValue.2.imageFileName'}
+            label={'coreValue3_imageFileName'}
             width="224px"
             height="190px"
           />
           <StInputBox>
             <StInput
-              {...register('coreValue.2.value')}
+              {...register('coreValue3_value', {
+                required: true && VALIDATION_CHECK.required.errorText,
+              })}
+              isError={errors.coreValue3_value?.message !== undefined}
+              errorMessage={errors.coreValue3_value?.message as string}
               labelText="가치"
               placeholder="ex. 화합"
             />
             <StInput
-              {...register('coreValue.2.description')}
+              {...register('coreValue3_description', {
+                required: true && VALIDATION_CHECK.required.errorText,
+              })}
+              isError={errors.coreValue3_description?.message !== undefined}
+              errorMessage={errors.coreValue3_description?.message as string}
               labelText="가치 설명"
               descriptionText="호버 시, 보이는 문구예요."
               placeholder="ex. 서로를 배려하며 함께 화합하는 사람"

--- a/src/components/org/OrgAdmin/AboutSection/Curriculum/index.tsx
+++ b/src/components/org/OrgAdmin/AboutSection/Curriculum/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
-import { PART_LIST } from '@/utils/org';
+import { PART_LIST, VALIDATION_CHECK } from '@/utils/org';
 
 import PartCategory from '../../PartCategory';
 import { StInput, StTitle, StWrapper } from '../style';
@@ -16,7 +16,10 @@ const CURRICULUM = PART_LIST.reduce(
 );
 
 const Curriculum = () => {
-  const { register } = useFormContext();
+  const {
+    register,
+    formState: { errors },
+  } = useFormContext();
 
   const [selectedPart, setSelectedPart] = useState('기획');
 
@@ -39,7 +42,17 @@ const Curriculum = () => {
                 0{idx + 1}
               </StWeek>
               <StInput
-                {...register(`partCurriculum.${selectedPart}.${idx}`)}
+                {...register(`partCurriculum_${selectedPart}_${idx}`, {
+                  required: true && VALIDATION_CHECK.required.errorText,
+                })}
+                isError={
+                  errors[`partCurriculum_${selectedPart}_${idx}`]?.message !==
+                  undefined
+                }
+                errorMessage={
+                  errors[`partCurriculum_${selectedPart}_${idx}`]
+                    ?.message as string
+                }
                 id={`${selectedPart} week${idx}`}
                 style={{ width: '553px' }}
                 placeholder={`${selectedPart} 파트 ${idx + 1}주차 커리큘럼을 작성해주세요.`}

--- a/src/components/org/OrgAdmin/AboutSection/Executives/ExecInfo.tsx
+++ b/src/components/org/OrgAdmin/AboutSection/Executives/ExecInfo.tsx
@@ -1,5 +1,7 @@
 import { useFormContext } from 'react-hook-form';
 
+import { VALIDATION_CHECK } from '@/utils/org';
+
 import MyDropzone from '../../MyDropzone';
 import IcBehanceLogo from '../assets/IcBehanceLogo';
 import IcGithubLogo from '../assets/IcGithubLogo';
@@ -15,7 +17,10 @@ interface ExecInfoProps {
 
 const ExecInfo = ({ selectedExec }: ExecInfoProps) => {
   const method = useFormContext();
-  const { register } = method;
+  const {
+    register,
+    formState: { errors },
+  } = method;
 
   return (
     <>
@@ -24,46 +29,58 @@ const ExecInfo = ({ selectedExec }: ExecInfoProps) => {
         <StDescription>사진은 1:1 비율로 올려주세요.</StDescription>
         <MyDropzone
           method={method}
-          label={`${selectedExec}.profileImageFileName`}
+          label={`${selectedExec}_profileImageFileName`}
           width="168px"
           height="168px"
           shape="circle"
         />
       </StPhotoWrapper>
       <StInput
-        {...register(`${selectedExec}.name`)}
+        {...register(`${selectedExec}_name`, {
+          required: true && VALIDATION_CHECK.required.errorText,
+        })}
+        isError={errors[`${selectedExec}_name`]?.message !== undefined}
+        errorMessage={errors[`${selectedExec}_name`]?.message as string}
         labelText="이름"
         placeholder="ex. 김솝트"
       />
       <StInput
-        {...register(`${selectedExec}.affiliation`)}
+        {...register(`${selectedExec}_affiliation`, {
+          required: true && VALIDATION_CHECK.required.errorText,
+        })}
+        isError={errors[`${selectedExec}_affiliation`]?.message !== undefined}
+        errorMessage={errors[`${selectedExec}_affiliation`]?.message as string}
         labelText="소속"
         placeholder="ex. 솝트대학교 / 솝트컴퍼니 / 앱잼 프로덕트명"
       />
       <StInput
-        {...register(`${selectedExec}.introduction`)}
+        {...register(`${selectedExec}_introduction`, {
+          required: true && VALIDATION_CHECK.required.errorText,
+        })}
+        isError={errors[`${selectedExec}_introduction`]?.message !== undefined}
+        errorMessage={errors[`${selectedExec}_introduction`]?.message as string}
         labelText="한 줄 소개"
         placeholder="ex. 새로운 도전을 위해 과감히 용기내는 사람"
       />
       <StSNSWrapper>
         <span>SNS</span>
         <SNSInput
-          label={`${selectedExec}.sns.email`}
+          label={`${selectedExec}_sns_email`}
           icon={IcMailLogo}
           placeholder="ex. 000@sopt.org"
         />
         <SNSInput
-          label={`${selectedExec}.sns.linkedin`}
+          label={`${selectedExec}_sns_linkedin`}
           icon={IcLinkedinLogo}
           placeholder="ex. https://www.linkedin.com/..."
         />
         <SNSInput
-          label={`${selectedExec}.sns.github`}
+          label={`${selectedExec}_sns_github`}
           icon={IcGithubLogo}
           placeholder="ex. https://github.com/..."
         />
         <SNSInput
-          label={`${selectedExec}.sns.behance`}
+          label={`${selectedExec}_sns_behance`}
           icon={IcBehanceLogo}
           placeholder="ex. https://www.behance.net/..."
         />

--- a/src/components/org/OrgAdmin/RecruitSection/Fna.tsx
+++ b/src/components/org/OrgAdmin/RecruitSection/Fna.tsx
@@ -32,7 +32,7 @@ const Fna = () => {
         <StFnaWrapper>
           <StTextArea
             {...register(
-              `recruitQuestion.${selectedPart}.questions.0.question`,
+              `recruitQuestion_${selectedPart}_questions_0_question`,
               {
                 required: true && VALIDATION_CHECK.required.errorText,
               },
@@ -43,24 +43,36 @@ const Fna = () => {
             fixedHeight={74}
             maxHeight={74}
             placeholder="질문을 입력해주세요."
-            isError={errors.partCurriculum?.message != undefined}
-            errorMessage={errors.partCurriculum?.message as string}
+            isError={
+              errors[`recruitQuestion_${selectedPart}_questions_0_question`]
+                ?.message != undefined
+            }
+            errorMessage={
+              errors[`recruitQuestion_${selectedPart}_questions_0_question`]
+                ?.message as string
+            }
           />
           <StTextArea
-            {...register(`recruitQuestion.${selectedPart}.questions.0.answer`, {
+            {...register(`recruitQuestion_${selectedPart}_questions_0_answer`, {
               required: true && VALIDATION_CHECK.required.errorText,
             })}
             fixedHeight={74}
             maxHeight={74}
             placeholder="답변을 입력해주세요."
-            isError={errors.partCurriculum?.message != undefined}
-            errorMessage={errors.partCurriculum?.message as string}
+            isError={
+              errors[`recruitQuestion_${selectedPart}_questions_0_answer`]
+                ?.message != undefined
+            }
+            errorMessage={
+              errors[`recruitQuestion_${selectedPart}_questions_0_answer`]
+                ?.message as string
+            }
           />
         </StFnaWrapper>
         <StFnaWrapper>
           <StTextArea
             {...register(
-              `recruitQuestion.${selectedPart}.questions.1.question`,
+              `recruitQuestion_${selectedPart}_questions_1_question`,
               {
                 required: true && VALIDATION_CHECK.required.errorText,
               },
@@ -71,24 +83,36 @@ const Fna = () => {
             fixedHeight={74}
             maxHeight={74}
             placeholder="질문을 입력해주세요."
-            isError={errors.partCurriculum?.message != undefined}
-            errorMessage={errors.partCurriculum?.message as string}
+            isError={
+              errors[`recruitQuestion_${selectedPart}_questions_1_question`]
+                ?.message != undefined
+            }
+            errorMessage={
+              errors[`recruitQuestion_${selectedPart}_questions_1_question`]
+                ?.message as string
+            }
           />
           <StTextArea
-            {...register(`recruitQuestion.${selectedPart}.questions.1.answer`, {
+            {...register(`recruitQuestion_${selectedPart}_questions_1_answer`, {
               required: true && VALIDATION_CHECK.required.errorText,
             })}
             fixedHeight={74}
             maxHeight={74}
             placeholder="답변을 입력해주세요."
-            isError={errors.partCurriculum?.message != undefined}
-            errorMessage={errors.partCurriculum?.message as string}
+            isError={
+              errors[`recruitQuestion_${selectedPart}_questions_1_answer`]
+                ?.message != undefined
+            }
+            errorMessage={
+              errors[`recruitQuestion_${selectedPart}_questions_1_answer`]
+                ?.message as string
+            }
           />
         </StFnaWrapper>
         <StFnaWrapper>
           <StTextArea
             {...register(
-              `recruitQuestion.${selectedPart}.questions.2.question`,
+              `recruitQuestion_${selectedPart}_questions_2_question`,
               {
                 required: true && VALIDATION_CHECK.required.errorText,
               },
@@ -99,18 +123,30 @@ const Fna = () => {
             fixedHeight={74}
             maxHeight={74}
             placeholder="질문을 입력해주세요."
-            isError={errors.partCurriculum?.message != undefined}
-            errorMessage={errors.partCurriculum?.message as string}
+            isError={
+              errors[`recruitQuestion_${selectedPart}_questions_2_question`]
+                ?.message != undefined
+            }
+            errorMessage={
+              errors[`recruitQuestion_${selectedPart}_questions_2_question`]
+                ?.message as string
+            }
           />
           <StTextArea
-            {...register(`recruitQuestion.${selectedPart}.questions.2.answer`, {
+            {...register(`recruitQuestion_${selectedPart}_questions_2_answer`, {
               required: true && VALIDATION_CHECK.required.errorText,
             })}
             fixedHeight={74}
             maxHeight={74}
             placeholder="답변을 입력해주세요."
-            isError={errors.partCurriculum?.message != undefined}
-            errorMessage={errors.partCurriculum?.message as string}
+            isError={
+              errors[`recruitQuestion_${selectedPart}_questions_2_answer`]
+                ?.message != undefined
+            }
+            errorMessage={
+              errors[`recruitQuestion_${selectedPart}_questions_2_answer`]
+                ?.message as string
+            }
           />
         </StFnaWrapper>
       </StTextAreaWrapper>

--- a/src/components/org/OrgAdmin/RecruitSection/PartCurriculum.tsx
+++ b/src/components/org/OrgAdmin/RecruitSection/PartCurriculum.tsx
@@ -30,7 +30,7 @@ const PartCurriculum = () => {
       />
       <StTextAreaWrapper key={selectedPart}>
         <StTextArea
-          {...register(`recruitPartCurriculum.${selectedPart}.content`, {
+          {...register(`recruitPartCurriculum_${selectedPart}_content`, {
             required: true && VALIDATION_CHECK.required.errorText,
           })}
           topAddon={{
@@ -39,11 +39,17 @@ const PartCurriculum = () => {
           fixedHeight={158}
           maxHeight={158}
           placeholder="파트별 설명을 작성해주세요."
-          isError={errors.partCurriculum?.message != undefined}
-          errorMessage={errors.partCurriculum?.message as string}
+          isError={
+            errors[`recruitPartCurriculum_${selectedPart}_content`]?.message !=
+            undefined
+          }
+          errorMessage={
+            errors[`recruitPartCurriculum_${selectedPart}_content`]
+              ?.message as string
+          }
         />
         <StTextArea
-          {...register(`recruitPartCurriculum.${selectedPart}.preference`, {
+          {...register(`recruitPartCurriculum_${selectedPart}_preference`, {
             required: true && VALIDATION_CHECK.required.errorText,
           })}
           topAddon={{
@@ -55,8 +61,14 @@ const PartCurriculum = () => {
 ex.
 - 어려움과 고민을 편하게 나누고 공감할 수 있는 유대감과 열린 마음을 가진 분
 - 타 파트와 협업하며 존중과 신뢰를 바탕으로 원활한 팀워크를 만들어갈 수 있는 분`}
-          isError={errors.idealCandidate?.message != undefined}
-          errorMessage={errors.idealCandidate?.message as string}
+          isError={
+            errors[`recruitPartCurriculum_${selectedPart}_preference`]
+              ?.message != undefined
+          }
+          errorMessage={
+            errors[`recruitPartCurriculum_${selectedPart}_preference`]
+              ?.message as string
+          }
         />
       </StTextAreaWrapper>
     </StWrapper>


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

소개탭에 required 조건 추가 및 error 처리를 추가해주었어요. 

그런데 errors 객체 사용하는 과정에서 제가 register label로 사용하던 방식(이전 PR 참고)이 타입에러를 발생시키더라구요. 
빨간줄을 해결하기 위해서는 제가 사용했던 API 스키마와 동일한 구조가 될 수 있도록 FormValue 타입을 따로 선언해줘야 하는 것으로 보였는데, 
현재는 그렇게 타입을 고도화할 시간이 없어서 일단 객체 구조였던 register label을 모두 flatten 시켜서 string화 해주었습니다. 

제 컨벤션을 적용시켰던 지원하기 탭에서도, 언석오빠가 최초에 작업해주었던 isError 및 errorMessage가 다 정상작동 하고 있지 않더라구요 
그래서 label 모두 flatten 시켜주고 errors 처리도 정상화시켜주었습니다. 


https://github.com/user-attachments/assets/3d7aa44c-a7ce-44e3-aeb2-bac8dd5d5262

