### PR TITLE
[FEAUTRE] 공홈 어드민 공통 탭 hook form 연결

### DIFF
--- a/src/components/org/OrgAdmin/CommonSection/BrandingColor.tsx
+++ b/src/components/org/OrgAdmin/CommonSection/BrandingColor.tsx
@@ -11,11 +11,6 @@ import BrandingSubColor from './BrandingSubColor';
 import ColorInputField from './ColorInputField';
 
 const BrandingColor = () => {
-  const [mainColor, setMainColor] = useState('');
-  const [lowColor, setLowColor] = useState('');
-  const [highColor, setHighColor] = useState('');
-  const [subGrayColor, setSubGrayColor] = useState('');
-
   return (
     <StWrapper>
       <StTitleWrapper>
@@ -23,28 +18,10 @@ const BrandingColor = () => {
         <StDescription>다크 모드를 고려하여 선정해주세요.</StDescription>
       </StTitleWrapper>
       <StInputWrapper>
-        <ColorInputField
-          label="키컬러 (메인)"
-          id="keyColorMain"
-          colorValue={mainColor}
-          onSetColorValue={(val: string) => setMainColor(val)}
-        />
-        <ColorInputField
-          label="키컬러 (저명도)"
-          id="keyColorLow"
-          colorValue={lowColor}
-          onSetColorValue={(val: string) => setLowColor(val)}
-        />
-        <ColorInputField
-          label="키컬러 (고명도)"
-          id="keyColorHigh"
-          colorValue={highColor}
-          onSetColorValue={(val: string) => setHighColor(val)}
-        />
-        <BrandingSubColor
-          subGrayColor={subGrayColor}
-          onSetSubGrayColor={setSubGrayColor}
-        />
+        <ColorInputField label="키컬러 (메인)" id="brandingColor_main" />
+        <ColorInputField label="키컬러 (저명도)" id="brandingColor_low" />
+        <ColorInputField label="키컬러 (고명도)" id="brandingColor_high" />
+        {/* <BrandingSubColor /> */}
       </StInputWrapper>
     </StWrapper>
   );

--- a/src/components/org/OrgAdmin/CommonSection/BrandingColor.tsx
+++ b/src/components/org/OrgAdmin/CommonSection/BrandingColor.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import {
   StDescription,
   StInputWrapper,

--- a/src/components/org/OrgAdmin/CommonSection/BrandingColor.tsx
+++ b/src/components/org/OrgAdmin/CommonSection/BrandingColor.tsx
@@ -21,7 +21,7 @@ const BrandingColor = () => {
         <ColorInputField label="키컬러 (메인)" id="brandingColor_main" />
         <ColorInputField label="키컬러 (저명도)" id="brandingColor_low" />
         <ColorInputField label="키컬러 (고명도)" id="brandingColor_high" />
-        {/* <BrandingSubColor /> */}
+        <BrandingSubColor />
       </StInputWrapper>
     </StWrapper>
   );

--- a/src/components/org/OrgAdmin/CommonSection/BrandingSubColor.tsx
+++ b/src/components/org/OrgAdmin/CommonSection/BrandingSubColor.tsx
@@ -15,25 +15,17 @@ import {
   StInfoSubDescription,
   StInfoTitle,
   StInfoWrapper,
-  StSubColorDescription,
-  StSubColorTitle,
 } from './style';
 import { expandHexColor } from './utils';
 
-interface BrandingSubColorProps {
-  subGrayColor: string;
-  onSetSubGrayColor: (color: string) => void;
-}
-
-const BrandingSubColor = ({
-  subGrayColor,
-  onSetSubGrayColor,
-}: BrandingSubColorProps) => {
+const BrandingSubColor = () => {
   const [isInfoVisible, setIsInfoVisible] = useState(false);
 
   const {
     register,
     formState: { errors },
+    watch,
+    setValue,
   } = useFormContext();
 
   const handleInfoToggle = (e: MouseEvent<HTMLButtonElement>) => {
@@ -48,7 +40,7 @@ const BrandingSubColor = ({
           <IconInfoCircle />
         </StInfoButton>
         <StInput
-          {...register('subColor', {
+          {...register('brandingColor_point', {
             required: true && VALIDATION_CHECK.required.errorText,
           })}
           required
@@ -58,15 +50,13 @@ const BrandingSubColor = ({
           type="text"
           maxLength={9}
           placeholder="ex. #ffffff"
-          value={subGrayColor}
-          onChange={(e) => onSetSubGrayColor(e.target.value)}
           isError={errors.subColor?.message != undefined}
           errorMessage={errors.subColor?.message as string}
         />
         <StColorPreview
           type="color"
-          value={expandHexColor(subGrayColor)}
-          onChange={(e) => onSetSubGrayColor(e.target.value)}
+          value={expandHexColor(watch('brandingColor_point'))}
+          onChange={(e) => setValue('brandingColor_point', e.target.value)}
         />
         <StInfoWrapper isVisible={isInfoVisible}>
           <StInfoTitle>

--- a/src/components/org/OrgAdmin/CommonSection/ColorInputField.tsx
+++ b/src/components/org/OrgAdmin/CommonSection/ColorInputField.tsx
@@ -9,19 +9,14 @@ import { expandHexColor } from './utils';
 interface ColorInputFieldProps {
   label: string;
   id: string;
-  colorValue: string;
-  onSetColorValue: (value: string) => void;
 }
 
-const ColorInputField = ({
-  label,
-  id,
-  colorValue,
-  onSetColorValue,
-}: ColorInputFieldProps) => {
+const ColorInputField = ({ label, id }: ColorInputFieldProps) => {
   const {
     register,
     formState: { errors },
+    watch,
+    setValue,
   } = useFormContext();
 
   return (
@@ -36,15 +31,13 @@ const ColorInputField = ({
         type="text"
         maxLength={9}
         placeholder="ex. #ffffff"
-        value={colorValue}
-        onChange={(e) => onSetColorValue(e.target.value)}
         isError={errors[id]?.message != undefined}
         errorMessage={errors[id]?.message as string}
       />
       <StColorPreview
         type="color"
-        value={expandHexColor(colorValue)}
-        onChange={(e) => onSetColorValue(e.target.value)}
+        value={expandHexColor(watch(id))}
+        onChange={(e) => setValue(id, e.target.value)}
       />
     </StColorWrapper>
   );

--- a/src/components/org/OrgAdmin/CommonSection/GenerationInformation.tsx
+++ b/src/components/org/OrgAdmin/CommonSection/GenerationInformation.tsx
@@ -51,21 +51,20 @@ const GenerationInformation = () => {
           errorMessage={errors.generation?.message as string}
         />
         <StInput
-          {...register('soptName', {
+          {...register('name', {
             required: true && VALIDATION_CHECK.required.errorText,
             maxLength: {
-              value: VALIDATION_CHECK.soptName.maxLength,
-              message: VALIDATION_CHECK.soptName.wrongLengthErrorText(),
+              value: VALIDATION_CHECK.name.maxLength,
+              message: VALIDATION_CHECK.name.wrongLengthErrorText(),
             },
           })}
           required
-          value={'AND SOPT'}
           labelText="기수명"
           id="sopt-name"
           type="text"
           placeholder="ex. 00 SOPT"
-          isError={errors.soptName?.message != undefined}
-          errorMessage={errors.soptName?.message as string}
+          isError={errors.name?.message != undefined}
+          errorMessage={errors.name?.message as string}
         />
       </StInputWrapper>
     </StWrapper>

--- a/src/components/org/OrgAdmin/CommonSection/RecruitSchedule.tsx
+++ b/src/components/org/OrgAdmin/CommonSection/RecruitSchedule.tsx
@@ -14,10 +14,9 @@ import { StDateWrapper, StRadioWrapper } from './style';
 interface ScheduleInputProps {
   id: string;
   label: string;
-  value: string;
 }
 
-const ScheduleInput = ({ id, label, value }: ScheduleInputProps) => {
+const ScheduleInput = ({ id, label }: ScheduleInputProps) => {
   const {
     register,
     formState: { errors },
@@ -30,8 +29,7 @@ const ScheduleInput = ({ id, label, value }: ScheduleInputProps) => {
       labelText={label}
       id={id}
       type="datetime-local"
-      value={value}
-      hasValue={!!value}
+      // hasValue={!!value}
       isError={!!errors[id]?.message}
       errorMessage={errors[id]?.message as string}
     />
@@ -59,38 +57,32 @@ const RecruitSchedule = () => {
       </StRadioWrapper>
       <StDateWrapper>
         <ScheduleInput
-          id="application-start"
+          id={`recruitSchedule_${group}_schedule_applicationStartTime`}
           label={`${group} 서류 접수 시작`}
-          value={''}
         />
         <ScheduleInput
-          id="application-end"
+          id={`recruitSchedule_${group}_schedule_applicationEndTime`}
           label={`${group} 서류 접수 마감`}
-          value={''}
         />
         <ScheduleInput
-          id="application-result"
+          id={`recruitSchedule_${group}_schedule_applicationResultTime`}
           label={`${group} 서류 결과 발표`}
-          value={''}
         />
       </StDateWrapper>
       <StDateWrapper>
         <ScheduleInput
-          id="interview-start"
+          id={`recruitSchedule_${group}_schedule_interviewStartTime`}
           label={`${group} 면접 시작`}
-          value={''}
         />
         <ScheduleInput
-          id="interview-end"
+          id={`recruitSchedule_${group}_schedule_interviewEndTime`}
           label={`${group} 면접 마감`}
-          value={''}
         />
       </StDateWrapper>
       <StDateWrapper>
         <ScheduleInput
-          id="final-result"
+          id={`recruitSchedule_${group}_schedule_finalResultTime`}
           label={`${group} 최종 결과 발표`}
-          value={''}
         />
       </StDateWrapper>
     </StWrapper>

--- a/src/components/org/OrgAdmin/CommonSection/RecruitSchedule.tsx
+++ b/src/components/org/OrgAdmin/CommonSection/RecruitSchedule.tsx
@@ -2,6 +2,8 @@ import { Chip } from '@sopt-makers/ui';
 import { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
+import { VALIDATION_CHECK } from '@/utils/org';
+
 import {
   StDescription,
   StInput,
@@ -25,7 +27,9 @@ const ScheduleInput = ({ id, label }: ScheduleInputProps) => {
 
   return (
     <StInput
-      {...register(id)}
+      {...register(id, {
+        required: true && VALIDATION_CHECK.required.errorText,
+      })}
       required
       labelText={label}
       id={id}

--- a/src/components/org/OrgAdmin/CommonSection/RecruitSchedule.tsx
+++ b/src/components/org/OrgAdmin/CommonSection/RecruitSchedule.tsx
@@ -20,6 +20,7 @@ const ScheduleInput = ({ id, label }: ScheduleInputProps) => {
   const {
     register,
     formState: { errors },
+    watch,
   } = useFormContext();
 
   return (
@@ -29,7 +30,7 @@ const ScheduleInput = ({ id, label }: ScheduleInputProps) => {
       labelText={label}
       id={id}
       type="datetime-local"
-      // hasValue={!!value}
+      hasValue={!!watch(id)}
       isError={!!errors[id]?.message}
       errorMessage={errors[id]?.message as string}
     />
@@ -55,36 +56,38 @@ const RecruitSchedule = () => {
           YB
         </Chip>
       </StRadioWrapper>
-      <StDateWrapper>
-        <ScheduleInput
-          id={`recruitSchedule_${group}_schedule_applicationStartTime`}
-          label={`${group} 서류 접수 시작`}
-        />
-        <ScheduleInput
-          id={`recruitSchedule_${group}_schedule_applicationEndTime`}
-          label={`${group} 서류 접수 마감`}
-        />
-        <ScheduleInput
-          id={`recruitSchedule_${group}_schedule_applicationResultTime`}
-          label={`${group} 서류 결과 발표`}
-        />
-      </StDateWrapper>
-      <StDateWrapper>
-        <ScheduleInput
-          id={`recruitSchedule_${group}_schedule_interviewStartTime`}
-          label={`${group} 면접 시작`}
-        />
-        <ScheduleInput
-          id={`recruitSchedule_${group}_schedule_interviewEndTime`}
-          label={`${group} 면접 마감`}
-        />
-      </StDateWrapper>
-      <StDateWrapper>
-        <ScheduleInput
-          id={`recruitSchedule_${group}_schedule_finalResultTime`}
-          label={`${group} 최종 결과 발표`}
-        />
-      </StDateWrapper>
+      <div key={group}>
+        <StDateWrapper>
+          <ScheduleInput
+            id={`recruitSchedule_${group}_schedule_applicationStartTime`}
+            label={`${group} 서류 접수 시작`}
+          />
+          <ScheduleInput
+            id={`recruitSchedule_${group}_schedule_applicationEndTime`}
+            label={`${group} 서류 접수 마감`}
+          />
+          <ScheduleInput
+            id={`recruitSchedule_${group}_schedule_applicationResultTime`}
+            label={`${group} 서류 결과 발표`}
+          />
+        </StDateWrapper>
+        <StDateWrapper>
+          <ScheduleInput
+            id={`recruitSchedule_${group}_schedule_interviewStartTime`}
+            label={`${group} 면접 시작`}
+          />
+          <ScheduleInput
+            id={`recruitSchedule_${group}_schedule_interviewEndTime`}
+            label={`${group} 면접 마감`}
+          />
+        </StDateWrapper>
+        <StDateWrapper>
+          <ScheduleInput
+            id={`recruitSchedule_${group}_schedule_finalResultTime`}
+            label={`${group} 최종 결과 발표`}
+          />
+        </StDateWrapper>
+      </div>
     </StWrapper>
   );
 };

--- a/src/components/org/OrgAdmin/CommonSection/style.ts
+++ b/src/components/org/OrgAdmin/CommonSection/style.ts
@@ -46,6 +46,7 @@ export const StColorPreview = styled.input`
   width: 48px;
   height: 48px;
   padding: 0;
+  margin-bottom: 8px;
   border: none;
   border-radius: 10px;
   cursor: pointer;

--- a/src/utils/org.ts
+++ b/src/utils/org.ts
@@ -9,7 +9,7 @@ export const VALIDATION_CHECK = {
     errorText: '잘못된 기수예요.',
     wrongLengthErrorText: '2자리 수만 입력 가능해요.',
   },
-  soptName: {
+  name: {
     maxLength: 20,
     errorText: '잘못된 기수명이에요.',
     wrongLengthErrorText() {


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세
- closed #141 
<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

## ✅ PR Point
- 앞선 PR에서 말씀드린 것처럼 form label flatten 작업 동일하게 해주었습니다 
- colorPicker과 date input 쪽에서 hook form을 활용해서 조건부 스타일링 / 조건부 렌더링되도록 로직 반영했습니다 
- OB/YB 칩 선택 시 컴포넌트가 새로이 렌더링되지 않아 key prop 추가하기 위해 div wrapper 추가해주었습니다 

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

