### PR TITLE
[FIX] layout main 태그가 자식 요소에 중첩되는 문제 해결

### DIFF
--- a/src/components/common/Layout/style.ts
+++ b/src/components/common/Layout/style.ts
@@ -6,7 +6,7 @@ export const StLayout = styled.div`
   .main-wrapper {
     width: 100%;
     padding: 88px 0 0 212px;
-    main {
+    & > main {
       width: 100%;
 
       padding: 0px 49px 0px 124px;


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

- layout 에서 적용된 padding 값이 하위 요소의 main 요소에 중첩되어 적용되는 문제를 수정합니다.
- 선택자 지정을 통해 layout의 자식 main에만 padding이 적용되도록 수정했어요.


### AS-IS
<img width="400" alt="image" src="https://github.com/user-attachments/assets/8322bf61-f453-49bd-8f87-a18cdfd80341" />


### TO-BE
<img width="400" alt="image" src="https://github.com/user-attachments/assets/179ec26a-2c5c-4d74-8b46-8fb9cc6040af" />

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

## 😭 어려웠던 점

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->
