### PR TITLE
[BUG] 공통 탭 서브 컬러 input들 정렬 맞추고 컬러 코드에 # 제거하기

### DIFF
--- a/src/components/org/OrgAdmin/CommonSection/BrandingSubColor.tsx
+++ b/src/components/org/OrgAdmin/CommonSection/BrandingSubColor.tsx
@@ -4,8 +4,15 @@ import { useFormContext } from 'react-hook-form';
 
 import { VALIDATION_CHECK } from '@/utils/org';
 
+import { StInputLabel } from '../AboutSection/style';
+import RequiredIcon from '../assets/RequiredIcon';
 import { StInput, StInputBox } from '../style';
-import { StColorWrapper, StInfoButton, StSubColorPreview } from './style';
+import {
+  StColorWrapper,
+  StInfoButton,
+  StSubColorDescription,
+  StSubColorPreview,
+} from './style';
 import { expandHexColor } from './utils';
 
 const BrandingSubColor = ({
@@ -23,6 +30,13 @@ const BrandingSubColor = ({
   return (
     <StInputBox>
       <StColorWrapper>
+        <StInputLabel>
+          <span>서브 컬러 (강조 그레이 컬러)</span>
+          <RequiredIcon />
+        </StInputLabel>
+        <StSubColorDescription>
+          강조하고 싶은 박스의 그레이 컬러를 지정해주세요.
+        </StSubColorDescription>
         <StInfoButton onClick={onInfoToggle}>
           <IconInfoCircle />
         </StInfoButton>
@@ -31,8 +45,6 @@ const BrandingSubColor = ({
             required: true && VALIDATION_CHECK.required.errorText,
           })}
           required
-          labelText="서브 컬러 (강조 그레이 컬러)"
-          descriptionText="강조하고 싶은 박스의 그레이 컬러를 지정해주세요."
           id="sub-color"
           type="text"
           maxLength={8}

--- a/src/components/org/OrgAdmin/CommonSection/BrandingSubColor.tsx
+++ b/src/components/org/OrgAdmin/CommonSection/BrandingSubColor.tsx
@@ -35,15 +35,17 @@ const BrandingSubColor = ({
           descriptionText="강조하고 싶은 박스의 그레이 컬러를 지정해주세요."
           id="sub-color"
           type="text"
-          maxLength={9}
-          placeholder="ex. #ffffff"
+          maxLength={8}
+          placeholder="ex. ffffff"
           isError={errors.brandingColor_point?.message != undefined}
           errorMessage={errors.brandingColor_point?.message as string}
         />
         <StSubColorPreview
           type="color"
           value={expandHexColor(watch('brandingColor_point'))}
-          onChange={(e) => setValue('brandingColor_point', e.target.value)}
+          onChange={(e) =>
+            setValue('brandingColor_point', e.target.value.replace('#', ''))
+          }
         />
       </StColorWrapper>
     </StInputBox>

--- a/src/components/org/OrgAdmin/CommonSection/BrandingSubColor.tsx
+++ b/src/components/org/OrgAdmin/CommonSection/BrandingSubColor.tsx
@@ -5,7 +5,7 @@ import { useFormContext } from 'react-hook-form';
 import { VALIDATION_CHECK } from '@/utils/org';
 
 import { StInput, StInputBox } from '../style';
-import { StColorPreview, StColorWrapper, StInfoButton } from './style';
+import { StColorWrapper, StInfoButton, StSubColorPreview } from './style';
 import { expandHexColor } from './utils';
 
 const BrandingSubColor = ({
@@ -40,7 +40,7 @@ const BrandingSubColor = ({
           isError={errors.brandingColor_point?.message != undefined}
           errorMessage={errors.brandingColor_point?.message as string}
         />
-        <StColorPreview
+        <StSubColorPreview
           type="color"
           value={expandHexColor(watch('brandingColor_point'))}
           onChange={(e) => setValue('brandingColor_point', e.target.value)}

--- a/src/components/org/OrgAdmin/CommonSection/ColorInputField.tsx
+++ b/src/components/org/OrgAdmin/CommonSection/ColorInputField.tsx
@@ -29,15 +29,15 @@ const ColorInputField = ({ label, id }: ColorInputFieldProps) => {
         labelText={label}
         id={id}
         type="text"
-        maxLength={9}
-        placeholder="ex. #ffffff"
+        maxLength={8}
+        placeholder="ex. ffffff"
         isError={errors[id]?.message != undefined}
         errorMessage={errors[id]?.message as string}
       />
       <StColorPreview
         type="color"
         value={expandHexColor(watch(id))}
-        onChange={(e) => setValue(id, e.target.value)}
+        onChange={(e) => setValue(id, e.target.value.replace('#', ''))}
       />
     </StColorWrapper>
   );

--- a/src/components/org/OrgAdmin/CommonSection/style.ts
+++ b/src/components/org/OrgAdmin/CommonSection/style.ts
@@ -69,14 +69,14 @@ export const StColorPreview = styled.input`
 `;
 
 export const StSubColorPreview = styled(StColorPreview)`
-  top: 42px;
+  top: 50px;
 `;
 
 export const StInfoButton = styled.button`
   ${fontsObject.LABEL_3_14_SB};
 
   position: absolute;
-  top: 0px;
+  top: 1px;
   left: 175px;
   vertical-align: middle;
   width: 16px;

--- a/src/components/org/OrgAdmin/CommonSection/style.ts
+++ b/src/components/org/OrgAdmin/CommonSection/style.ts
@@ -147,5 +147,6 @@ export const StSubColorTitle = styled(StInputLabel)`
 export const StSubColorDescription = styled.p`
   ${fontsObject.LABEL_4_12_SB}
 
+  margin-bottom: 8px;
   color: ${colors.gray300};
 `;

--- a/src/components/org/OrgAdmin/CommonSection/style.ts
+++ b/src/components/org/OrgAdmin/CommonSection/style.ts
@@ -68,6 +68,10 @@ export const StColorPreview = styled.input`
   }
 `;
 
+export const StSubColorPreview = styled(StColorPreview)`
+  top: 42px;
+`;
+
 export const StInfoButton = styled.button`
   ${fontsObject.LABEL_3_14_SB};
 

--- a/src/components/org/OrgAdmin/CommonSection/utils.ts
+++ b/src/components/org/OrgAdmin/CommonSection/utils.ts
@@ -1,14 +1,14 @@
 const isValidHexColor = (hex: string) => {
-  const hexRegex = /^#([0-9A-Fa-f]{3}){1,2}$/;
+  const hexRegex = /^([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$/;
   return hexRegex.test(hex);
 };
 
 export const expandHexColor = (hex: string) => {
   if (!isValidHexColor(hex)) return '#ffffff';
 
-  if (hex.length === 4) {
-    return `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`;
+  if (hex.length === 3) {
+    return `#${hex[0]}${hex[0]}${hex[1]}${hex[1]}${hex[2]}${hex[2]}`;
   }
 
-  return hex;
+  return `#${hex}`;
 };


### PR DESCRIPTION
## ✅ PR Point

1. 서브 컬러 preview랑 서브 컬러 input 정렬 맞췄습니다
2. 입력하기 편하라고 서브 컬러에 # 입력 안해도 되도록 수정했습니다
3. 서브 컬러 title, description 간격 수정했어요

![스크린샷 2024-12-27 오후 12 01 36](https://github.com/user-attachments/assets/2cf1615e-b126-4cdd-8133-c29fa0ef5a99)
