### PR TITLE
[BUG] 폰트가 두껍게 보이는 오류 해결 및 폰트 수정

### DIFF
--- a/src/components/org/OrgAdmin/AboutSection/Executives/ExecInfo.tsx
+++ b/src/components/org/OrgAdmin/AboutSection/Executives/ExecInfo.tsx
@@ -30,7 +30,9 @@ const ExecInfo = ({ selectedExec }: ExecInfoProps) => {
           <span>프로필 사진</span>
           <RequiredIcon />
         </StInputLabel>
-        <StDescription>사진은 1:1 비율로 올려주세요.</StDescription>
+        <StDescription>
+          사진은 1:1 비율로 올려주세요. 사진 용량은 00mb 아래로 첨부해주세요.
+        </StDescription>
         <MyDropzone
           method={method}
           label={`member.${selectedExec}.profileImageFileName`}

--- a/src/components/org/OrgAdmin/AboutSection/style.ts
+++ b/src/components/org/OrgAdmin/AboutSection/style.ts
@@ -40,7 +40,7 @@ export const StInputLabel = styled.label`
 `;
 
 export const StDescription = styled.p`
-  ${fontsObject.LABEL_4_12_SB};
+  ${fontsObject.LABEL_3_14_SB};
   color: ${colors.gray300};
 `;
 

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -22,6 +22,10 @@ const global: Interpolation<Theme> = (theme: Theme) => css`
     overflow-y: scroll;
     overflow-x: hidden;
 
+    font-smooth: never;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+
     &::-webkit-scrollbar {
       width: 1.2rem;
     }


### PR DESCRIPTION
## ✅ PR Point

### 🪐 폰트가 두껍게 보이는 에러 해결
```css
font-smooth: never;
-webkit-font-smoothing: antialiased;
-moz-osx-font-smoothing: grayscale;
```

#### 전
![스크린샷 2024-12-27 오전 11 28 31](https://github.com/user-attachments/assets/f8589394-5d43-452c-ba15-17a99c956b10)

#### 후
![스크린샷 2024-12-27 오전 11 27 31](https://github.com/user-attachments/assets/ee33700c-3a1b-4052-a388-a77cf7b03008)

### 🪐 폰드 문구 수정 및 크기 수정
description font 크기를 12 -> 14로 수정했어요
![스크린샷 2024-12-27 오전 11 27 19](https://github.com/user-attachments/assets/34182609-d92f-41cf-8177-1dd8a23bcdfe)
