### PR TITLE
[BUG] 공홈 어드민 이미지 등록 했다 다른 탭 이동하면 해당 이미지 없어지는 에러 해결

### DIFF
--- a/src/components/org/OrgAdmin/MyDropzone/index.tsx
+++ b/src/components/org/OrgAdmin/MyDropzone/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { type MouseEvent, useCallback, useState } from 'react';
+import { type MouseEvent, useCallback, useEffect, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 import type { UseFormReturn } from 'react-hook-form';
 
@@ -33,6 +33,7 @@ const MyDropzone = ({
   const {
     register,
     setValue,
+    watch,
     formState: { errors },
   } = method;
 
@@ -57,7 +58,7 @@ const MyDropzone = ({
           setPreviewUrl(reader.result as string);
           setValue(
             label,
-            { fileName: sanitizedFileName, file },
+            { fileName: sanitizedFileName, file, previewUrl: reader.result },
             { shouldValidate: true },
           );
         };
@@ -79,6 +80,14 @@ const MyDropzone = ({
       'image/png': [],
     },
   });
+
+  useEffect(() => {
+    const storedData = watch(label);
+
+    if (storedData?.previewUrl) {
+      setPreviewUrl(storedData.previewUrl);
+    }
+  }, [label, watch]);
 
   return (
     <StImgButtonWrapper>


### PR DESCRIPTION
## ✅ PR Point

다른 탭 갔다 와도 preview 유지 되도록 했어요
state는 언마운트 되면 사라지니까 계속해서 값이 유지될 수 있는 react hook form의 register를 이용했어요

이때 dropzone은 `image name(변수명: fileName)`과 `image file(변수명: file)` 2개를 받고 있는데 
preview로 사용되는 데이터 형식과 image file로 받고 있던 file 데이터 형식이 서로 달라서 
`새로운 변수(변수명: previewUrl)`을 추가로 저장시킨 뒤 해당 값이 있으면 useEffect를 통해 이를 불러오도록 구현했어요

https://github.com/user-attachments/assets/eaa2099a-5b0b-40ab-922f-d8d225363bf3

더 좋은 방법이 있다면 언제나 환영입니다 :)