### PR TITLE
[FEAT] 공홈 어드민 QA용 매직버튼 만들었어요 

### DIFF
--- a/src/components/attendanceAdmin/session/SessionList/style.ts
+++ b/src/components/attendanceAdmin/session/SessionList/style.ts
@@ -2,6 +2,17 @@ import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { fontsObject } from '@sopt-makers/fonts';
 
+export const StDevHStack = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  gap: 10px;
+  margin-bottom: 15px;
+  & > p {
+    ${fontsObject.TITLE_7_14_SB}
+    color:  ${colors.gray10};
+  }
+`;
 export const StListHeader = styled.header`
   h1 {
     ${fontsObject.TITLE_1_32_SB}

--- a/src/components/org/OrgAdmin/hooks.ts
+++ b/src/components/org/OrgAdmin/hooks.ts
@@ -28,27 +28,27 @@ interface UseMutateSendDataProps {
   recruitHeaderImageFile: File;
 }
 
-const useMutateSendData = ({
-  headerImageFile,
-  coreValueImageFile1,
-  coreValueImageFile2,
-  coreValueImageFile3,
-  memberImageFile1,
-  memberImageFile2,
-  memberImageFile3,
-  memberImageFile4,
-  memberImageFile5,
-  memberImageFile6,
-  memberImageFile7,
-  memberImageFile8,
-  memberImageFile9,
-  memberImageFile10,
-  memberImageFile11,
-  memberImageFile12,
-  recruitHeaderImageFile,
-}: UseMutateSendDataProps) => {
+const useMutateSendData = (fileProps: UseMutateSendDataProps) => {
+  const {
+    headerImageFile,
+    coreValueImageFile1,
+    coreValueImageFile2,
+    coreValueImageFile3,
+    memberImageFile1,
+    memberImageFile2,
+    memberImageFile3,
+    memberImageFile4,
+    memberImageFile5,
+    memberImageFile6,
+    memberImageFile7,
+    memberImageFile8,
+    memberImageFile9,
+    memberImageFile10,
+    memberImageFile11,
+    memberImageFile12,
+    recruitHeaderImageFile,
+  } = fileProps;
   const { open } = useToast();
-
   const { mutate: sendMutate, isLoading: sendIsLoading } = useMutation({
     mutationFn: (
       data: AddAdminRequestDto,
@@ -68,10 +68,16 @@ const useMutateSendData = ({
         !headerImageURL ||
         !members ||
         !recruitHeaderImageURL
-      )
+      ) {
         throw new Error('presigned url put 준비 과정에 에러가 발생함.');
-
+      }
       try {
+        if (Object.values(fileProps).some((file) => !(file instanceof File))) {
+          alert(
+            '이미지가 정상적으로 올라가지 않았어요.\n이미지를 다시 첨부하고 재배포해주세요.',
+          );
+          return;
+        }
         await Promise.all([
           sendPresignedURL(headerImageURL, headerImageFile).catch((err) => {
             console.error('소개 헤더 이미지 업로드 실패: ', err);

--- a/src/components/org/OrgAdmin/index.tsx
+++ b/src/components/org/OrgAdmin/index.tsx
@@ -1,4 +1,4 @@
-import { useToast } from '@sopt-makers/ui';
+import { Button, useToast } from '@sopt-makers/ui';
 import { useState } from 'react';
 import {
   type FieldValues,
@@ -8,7 +8,10 @@ import {
 } from 'react-hook-form';
 
 import { AddAdminRequestDto } from '@/__generated__/org-types/data-contracts';
-import { StListHeader } from '@/components/attendanceAdmin/session/SessionList/style';
+import {
+  StDevHStack,
+  StListHeader,
+} from '@/components/attendanceAdmin/session/SessionList/style';
 import FilterButton from '@/components/common/FilterButton';
 import {
   type EXEC_TYPE,
@@ -49,7 +52,7 @@ function OrgAdmin() {
   const [introPart, setIntroPart] = useState<PART_KO>('기획');
 
   const methods = useForm({ mode: 'onBlur' });
-  const { handleSubmit, getValues, setError } = methods;
+  const { handleSubmit, getValues, setError, reset, setValue } = methods;
 
   const { open } = useToast();
 
@@ -272,11 +275,79 @@ function OrgAdmin() {
         ],
       })),
     };
+
     sendMutate(requestBody);
   };
 
+  const handleClickMagicButton = (type: 'SET' | 'GET' | 'IMAGE' | 'RESET') => {
+    if (type === 'SET') {
+      localStorage.setItem('org-admin', JSON.stringify(getValues()));
+      alert('데이터 임시저장 성공!');
+      return;
+    }
+    if (type === 'GET') {
+      const data = localStorage.getItem('org-admin');
+      if (!data) {
+        alert('저장된 데이터가 없음ㅠ');
+      } else {
+        reset(JSON.parse(data));
+        alert(
+          '데이터 불러오기 성공! \n소개탭 헤더를 반드시 다시 첨부해주세요!',
+        );
+      }
+      return;
+    }
+
+    if (type === 'IMAGE') {
+      const headerImage = getValues('headerImageFileName');
+      if (!(headerImage.file instanceof File)) {
+        alert('소개탭 헤더 넣어주세용');
+        return;
+      }
+      setValue('coreValue1.imageFileName', headerImage);
+      setValue('coreValue2.imageFileName', headerImage);
+      setValue('coreValue3.imageFileName', headerImage);
+      setValue('member.회장.profileImageFileName', headerImage);
+      setValue('member.부회장.profileImageFileName', headerImage);
+      setValue('member.총무.profileImageFileName', headerImage);
+      setValue('member.운영 팀장.profileImageFileName', headerImage);
+      setValue('member.미디어 팀장.profileImageFileName', headerImage);
+      setValue('member.메이커스 팀장.profileImageFileName', headerImage);
+      setValue('member.기획.profileImageFileName', headerImage);
+      setValue('member.디자인.profileImageFileName', headerImage);
+      setValue('member.안드로이드.profileImageFileName', headerImage);
+      setValue('member.iOS.profileImageFileName', headerImage);
+      setValue('member.웹.profileImageFileName', headerImage);
+      setValue('member.서버.profileImageFileName', headerImage);
+      setValue('recruitHeaderImage', headerImage);
+
+      alert('소개탭 헤더로 이미지 밀기 성공!');
+      return;
+    }
+    localStorage.removeItem('org-admin');
+
+    alert('데이터 초기화 성공! 새로고침하세용');
+  };
   return (
     <>
+      {process.env.NODE_ENV === 'development' && (
+        <StDevHStack>
+          <p>매직버튼</p>
+          <Button size="sm" onClick={() => handleClickMagicButton('SET')}>
+            임시저장
+          </Button>
+          <Button size="sm" onClick={() => handleClickMagicButton('GET')}>
+            불러오기
+          </Button>
+          <Button size="sm" onClick={() => handleClickMagicButton('IMAGE')}>
+            이미지 채우기
+          </Button>
+          <Button size="sm" onClick={() => handleClickMagicButton('RESET')}>
+            데이터삭제
+          </Button>
+        </StDevHStack>
+      )}
+
       <StListHeader>
         <h1>공홈 관리</h1>
         <FilterButton

--- a/src/components/org/OrgAdmin/index.tsx
+++ b/src/components/org/OrgAdmin/index.tsx
@@ -300,7 +300,7 @@ function OrgAdmin() {
 
     if (type === 'IMAGE') {
       const headerImage = getValues('headerImageFileName');
-      if (!(headerImage.file instanceof File)) {
+      if (!(headerImage?.file instanceof File)) {
         alert('소개탭 헤더 넣어주세용');
         return;
       }


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세
QA할 때 매번 리로드되면 데이터 날아가고 폼 다 채워야하는게 너무 끔찍해서 제가 쓰려고 불친절한 매직버튼 만들었어요 
요구사항 없던거라 진짜 대충 만들었으니 QA 끝나면 다시 지우든 아니면 괜찮다 싶으면 좀 다듬어서 살리든 하면 될 것 같아용 

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

## ✅ PR Point
**주 기능** : 폼에 채운 데이터 임시 저장 및 복구 가능 

**기능 설명** : 
- `임시저장` : 현재 폼에 채워져있는 내용들을 로컬스토리지에 임시저장
- `불러오기` : 로컬 스토리지에 저장되어있는 폼 데이터를 불러와서 폼에 입혀요
- `이미지 채우기` : 이미지File은 로컬스토리지로 저장 및 복구가 안됩니다.(할람할이지만..) 그래서 이미지는 따로 채워주어야 하는데, 이미지만 하나하나 넣는것도 너무 귀찮은 과정이라서 첫 이미지인 소개탭배너만 넣으면, 나머지 이미지 폼(임원진 프로필, 지원하기 헤더 등등)은 다 소개탭 배너 이미지로 밀어주게 만들었어요. (다른탭 갔다오면 미리보기도 다 채워짐)
- `데이터삭제` : 로컬 스토리지 데이터를 날려줍니다 

**활용하는 법  정리** 
1. 일단 처음엔 폼 내용 다 채운다 (이미지는 다 안채워도됨. 어차피 임시저장 제대로 안됨) 
2. `임시저장` 누르기 
----- 재접속 / 리로드 -----
1. `불러오기` 누르기
2. 이미지폼은 하나하나 다시 채우거나 or 소개탭헤더만 채우고 `이미지 채우기` 버튼 누르기
3. 배포  (이미지 링크 잘못됐을 경우 알럿이 뜸. 그럼 다시 `이미지 채우기` 누르고 배포)


머지후에 이정이한테도 불친절한사용설명서 알려줄 예정입니답 (좀더 빨리만들걸)