### PR TITLE
[FIX] 최신소식 추가/삭제 에러 해결

### DIFF
--- a/src/components/org/OrgAdmin/HomeSection/api.ts
+++ b/src/components/org/OrgAdmin/HomeSection/api.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 
+import config from '@/configs/config';
 import { getToken } from '@/utils/auth';
 
 import { fetcher } from '../api';
@@ -18,7 +19,7 @@ export const getAdminInfo = async () => {
 
 export const postNews = async (formData: FormData) => {
   const res = await axios.post(
-    `${process.env.NEXT_PUBLIC_ORG_API}/admin/news`,
+    `${config.ORG_API_URL}/v2/admin/news`,
     formData,
     {
       headers: {
@@ -32,17 +33,11 @@ export const postNews = async (formData: FormData) => {
 };
 
 export const deleteNews = async (id: number) => {
-  const res = await axios.post(
-    `${process.env.NEXT_PUBLIC_ORG_API}/admin/news/delete`,
-    {
+  const response = await fetcher.POST('/admin/news/delete', {
+    body: {
       id,
     },
-    {
-      headers: {
-        Authorization: getToken('ACCESS'),
-      },
-    },
-  );
+  });
 
-  return res;
+  return response;
 };

--- a/src/components/org/OrgAdmin/HomeSection/api.ts
+++ b/src/components/org/OrgAdmin/HomeSection/api.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 
 import config from '@/configs/config';
 import { getToken } from '@/utils/auth';
+import { ACTIVITY_GENERATION } from '@/utils/generation';
 
 import { fetcher } from '../api';
 
@@ -9,7 +10,7 @@ export const getAdminInfo = async () => {
   const { data } = await fetcher.GET('/admin', {
     params: {
       query: {
-        generation: '34',
+        generation: ACTIVITY_GENERATION,
       },
     },
   });
@@ -33,11 +34,17 @@ export const postNews = async (formData: FormData) => {
 };
 
 export const deleteNews = async (id: number) => {
-  const response = await fetcher.POST('/admin/news/delete', {
-    body: {
+  const res = await axios.post(
+    `${config.ORG_API_URL}/v2/admin/news/delete`,
+    {
       id,
     },
-  });
+    {
+      headers: {
+        Authorization: getToken('ACCESS'),
+      },
+    },
+  );
 
-  return response;
+  return res;
 };


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

`fetcher` 반영 및 `axios` 엔드포인트에 `config.ORG_API_URL` 반영

## ✅ PR Point

기존에 `news post` API를 `axios`로 보내고 있었는데, 엔드포인트에 `env production`을 적용하지 않았어서 발생하였습니다. 이는 `fetcher` 적용하면 해결되긴 하는데 `news post` 경우 `fetcher` 사용하면 자꾸 500에러 발생해서 일단 기존 `axios` 유지하되 config의 어드민 API 엔드포인트 받아와서 넣어주었어요.

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

