### PR TITLE
[FIX] 배너어드민 진행완료 배너 수정 및 삭제 비활성화

### DIFF
--- a/src/components/bannerAdmin/BannerList/BannerList.tsx
+++ b/src/components/bannerAdmin/BannerList/BannerList.tsx
@@ -115,7 +115,6 @@ export const StItem = styled.div`
     margin-left: 3.9rem;
 
     text-align: left;
-    justify-content: start;
   }
 
   & > p {
@@ -136,7 +135,7 @@ export const StItem = styled.div`
   }
 
   & > p:nth-child(4) {
-    margin: 0;
+    margin-left: 2rem;
     text-align: center;
   }
 

--- a/src/components/bannerAdmin/BannerList/BannerList.tsx
+++ b/src/components/bannerAdmin/BannerList/BannerList.tsx
@@ -110,6 +110,14 @@ export const StItem = styled.div`
 
   white-space: nowrap;
 
+  & > div,
+  & > p {
+    margin-left: 3.9rem;
+
+    text-align: left;
+    justify-content: start;
+  }
+
   & > p {
     max-width: 12rem;
 
@@ -124,21 +132,17 @@ export const StItem = styled.div`
 
   & > h4 {
     margin-left: 3.5rem;
-
     text-align: left;
   }
 
-  & > div,
-  & > p {
-    margin-left: 3.9rem;
-
-    text-align: left;
-    justify-content: start;
+  & > p:nth-child(4) {
+    margin: 0;
+    text-align: center;
   }
 
   & > p:nth-child(6) {
-    text-align: left;
     margin-left: 1.8rem;
+    text-align: left;
   }
 
   &:hover {

--- a/src/components/bannerAdmin/BannerList/BannerList.tsx
+++ b/src/components/bannerAdmin/BannerList/BannerList.tsx
@@ -19,8 +19,8 @@ interface BannerListProps {
   onEditModalOpen: (modalState: number) => void;
   bannerList: Banner[];
 }
-const BannerList = ({ onEditModalOpen, bannerList }: BannerListProps) => {
 
+const BannerList = ({ onEditModalOpen, bannerList }: BannerListProps) => {
   return (
     <StItemWrapper>
       {bannerList?.map((banner) => (
@@ -42,11 +42,17 @@ const BannerList = ({ onEditModalOpen, bannerList }: BannerListProps) => {
           <p>{banner.start_date.replaceAll('-', '.')}</p>
           <p>{banner.end_date.replaceAll('-', '.')}</p>
           <StButtonLayout>
-            <BannerEditButton
-              onEditModalOpen={onEditModalOpen}
-              bannerId={banner.id}
-            />
-            <DeleteBannerButton bannerId={banner.id} />
+            {banner.status !== 'done' ? (
+              <>
+                <BannerEditButton
+                  onEditModalOpen={onEditModalOpen}
+                  bannerId={banner.id}
+                />
+                <DeleteBannerButton bannerId={banner.id} />
+              </>
+            ) : (
+              <StEmptyBox />
+            )}
           </StButtonLayout>
         </StItem>
       ))}
@@ -150,4 +156,8 @@ const StBannerTagWrapper = styled.div`
   & > p {
     ${fontsObject.LABEL_3_14_SB}
   }
+`;
+
+const StEmptyBox = styled.div`
+  width: 6.4rem;
 `;

--- a/src/components/bannerAdmin/BannerList/BannerList.tsx
+++ b/src/components/bannerAdmin/BannerList/BannerList.tsx
@@ -160,4 +160,5 @@ const StBannerTagWrapper = styled.div`
 
 const StEmptyBox = styled.div`
   width: 5.6rem;
+  height: 2.45rem;
 `;

--- a/src/components/bannerAdmin/BannerList/BannerList.tsx
+++ b/src/components/bannerAdmin/BannerList/BannerList.tsx
@@ -112,6 +112,7 @@ export const StItem = styled.div`
 
   & > p {
     max-width: 12rem;
+
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -127,9 +128,17 @@ export const StItem = styled.div`
     text-align: left;
   }
 
+  & > div,
+  & > p {
+    margin-left: 3.9rem;
+
+    text-align: left;
+    justify-content: start;
+  }
+
   & > p:nth-child(6) {
     text-align: left;
-    margin-left: 1.5rem;
+    margin-left: 1.8rem;
   }
 
   &:hover {
@@ -159,5 +168,5 @@ const StBannerTagWrapper = styled.div`
 `;
 
 const StEmptyBox = styled.div`
-  width: 6.4rem;
+  width: 5.6rem;
 `;

--- a/src/components/bannerAdmin/BannerList/BannerList.tsx
+++ b/src/components/bannerAdmin/BannerList/BannerList.tsx
@@ -96,7 +96,7 @@ export const StStatus = styled.h4<{ status: string }>`
 
 export const StItem = styled.div`
   display: grid;
-  grid-template-columns: 1fr 1fr 1.1fr 1fr 1fr 1fr 0.2fr;
+  grid-template-columns: 1fr 1fr 1.1fr 1fr 1fr 1.2fr 0.2fr;
 
   width: 100%;
 
@@ -109,13 +109,6 @@ export const StItem = styled.div`
   align-items: center;
 
   white-space: nowrap;
-
-  & > div,
-  & > p {
-    margin-left: 3.9rem;
-
-    text-align: left;
-  }
 
   & > p {
     max-width: 12rem;
@@ -135,13 +128,8 @@ export const StItem = styled.div`
   }
 
   & > p:nth-child(4) {
-    margin-left: 2rem;
+    margin-left: 1rem;
     text-align: center;
-  }
-
-  & > p:nth-child(6) {
-    margin-left: 1.8rem;
-    text-align: left;
   }
 
   &:hover {

--- a/src/components/bannerAdmin/Header/Header.tsx
+++ b/src/components/bannerAdmin/Header/Header.tsx
@@ -18,7 +18,7 @@ export default Header;
 
 const StHeader = styled.header`
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 0.5fr;
+  grid-template-columns: 1fr 1.2fr 1fr 1fr 1fr 1.2fr 0.8fr;
 
   padding: 1rem 0;
 
@@ -31,8 +31,7 @@ const StHeader = styled.header`
   border-bottom: 1px solid ${colors.gray700};
 
   & > h3 {
-    margin-left: 5rem;
-    text-align: left;
+    text-align: center;
 
     ${fontsObject.BODY_3_14_M};
     color: ${colors.gray100};
@@ -42,19 +41,11 @@ const StHeader = styled.header`
 
   & > h3:nth-child(1) {
     margin-left: 3.9rem;
+    text-align: left;
   }
 
-  & > h3:nth-child(4) {
-    margin-left: 3rem;
-  }
-
-  & > h3:nth-child(5) {
-    margin-left: 2rem;
-  }
-
-  & > h3:nth-of-type(6) {
-    margin-left: -2rem;
-
+  & > h3:nth-child(6) {
+    margin-left: 5rem;
     text-align: left;
   }
 `;

--- a/src/components/bannerAdmin/Header/Header.tsx
+++ b/src/components/bannerAdmin/Header/Header.tsx
@@ -31,7 +31,7 @@ const StHeader = styled.header`
   border-bottom: 1px solid ${colors.gray700};
 
   & > h3 {
-    margin-left: 3.9rem;
+    margin-left: 5rem;
     text-align: left;
 
     ${fontsObject.BODY_3_14_M};
@@ -40,12 +40,20 @@ const StHeader = styled.header`
     white-space: nowrap;
   }
 
+  & > h3:nth-child(1) {
+    margin-left: 3.9rem;
+  }
+
   & > h3:nth-child(4) {
     margin-left: 3rem;
   }
 
+  & > h3:nth-child(5) {
+    margin-left: 2rem;
+  }
+
   & > h3:nth-of-type(6) {
-    margin-left: 1rem;
+    margin-left: -2rem;
 
     text-align: left;
   }

--- a/src/components/bannerAdmin/Header/Header.tsx
+++ b/src/components/bannerAdmin/Header/Header.tsx
@@ -40,6 +40,10 @@ const StHeader = styled.header`
     white-space: nowrap;
   }
 
+  & > h3:nth-child(4) {
+    margin-left: 3rem;
+  }
+
   & > h3:nth-of-type(6) {
     margin-left: 1rem;
 

--- a/src/pages/bannerAdmin/index.tsx
+++ b/src/pages/bannerAdmin/index.tsx
@@ -71,6 +71,7 @@ const BannerAdminPage = () => {
             translator={bannerStatusTranslator(entireBannerList?.banners ?? [])}
             selectedInitial={tab}
             onChange={handleChangeTab}
+            css={{ marginTop: 'auto' }}
           />
           <SelectV2.Root
             visibleOptions={3}
@@ -87,6 +88,7 @@ const BannerAdminPage = () => {
                   '& > p': {
                     whiteSpace: 'nowrap',
                   },
+                  marginBottom: '1.2rem',
                 }}
               />
             </SelectV2.Trigger>
@@ -142,6 +144,8 @@ const StLayout = styled.div`
   display: flex;
 
   align-items: center;
+
+  border-bottom: 1px solid ${colors.gray800};
 `;
 
 const StTitle = styled.h1`

--- a/src/pages/bannerAdmin/index.tsx
+++ b/src/pages/bannerAdmin/index.tsx
@@ -71,7 +71,7 @@ const BannerAdminPage = () => {
             translator={bannerStatusTranslator(entireBannerList?.banners ?? [])}
             selectedInitial={tab}
             onChange={handleChangeTab}
-            css={{ marginTop: 'auto' }}
+            css={{ marginTop: 'auto', gap: '2.6rem' }}
           />
           <SelectV2.Root
             visibleOptions={3}


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

배너어드민 - 배너리스트에서 `진행 완료` 상태의 리스트의 경우 수정/삭제가 불가능하도록 수정

## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->
- 진행 완료 상태일 때 수정 / 삭제가 불가능하도록 버튼을 띄우지 않았습니다 !
이떄 아무것도 렌더링하지 않으면 테이블 레이아웃 잡아놓은 게 깨져서 Empty스타일 부여해줬습니다.

이외에도 자잘하게 테이블 정렬 & 스타일 맞춰줬습니당 !


