### PR TITLE
[REFACTOR] banner 생성 모달 qa (데이트피커 부분 제외)

### DIFF
--- a/src/components/bannerAdmin/BannerImageRegister.tsx
+++ b/src/components/bannerAdmin/BannerImageRegister.tsx
@@ -86,7 +86,7 @@ const BannerImageRegister = () => {
         <>
           <StDescriptionWrapper style={{ marginTop: '2rem' }}>
             <StDescription isError={!!errors.mobileImageFileName}>
-              <StDescriptionTitle>[PC]</StDescriptionTitle>{' '}
+              <StDescriptionTitle>[MO]</StDescriptionTitle>{' '}
               {`이미지는 ${moImageBaseWidth}*${moImageBaseHeight} px`}
               크기로 올려주세요.
               <p>(형식: PNG, 용량: 5MB 이내)</p>

--- a/src/components/bannerAdmin/BannerList/BannerList.tsx
+++ b/src/components/bannerAdmin/BannerList/BannerList.tsx
@@ -1,6 +1,10 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
+import { fontsObject } from '@sopt-makers/fonts';
+
 import { IcEdit, IcTrash } from '@/assets/icons';
 import BannerEditButton from '@/components/bannerAdmin/BannerEditButton';
-
 import BannerTag from '@/components/bannerAdmin/BannerTag/BannerTag';
 import DeleteBannerButton from '@/components/bannerAdmin/DeleteBannerButton';
 import { useFetchBannerList } from '@/services/api/banner/query';
@@ -10,11 +14,6 @@ import {
   translateLocation,
   translateStatus,
 } from '@/utils';
-
-import { css } from '@emotion/react';
-import styled from '@emotion/styled';
-import { colors } from '@sopt-makers/colors';
-import { fontsObject } from '@sopt-makers/fonts';
 
 interface BannerListProps {
   onEditModalOpen: (modalState: number) => void;

--- a/src/components/bannerAdmin/ContentTypeField.tsx
+++ b/src/components/bannerAdmin/ContentTypeField.tsx
@@ -6,9 +6,9 @@ import {
   StInputLabel,
   StRadioGroup,
 } from '@/components/bannerAdmin/CreateBannerModal';
+import FormController from '@/components/bannerAdmin/form/FormController';
 import { CONTENT_KEY, contentList } from '@/components/bannerAdmin/types/form';
 import RequiredIcon from '@/components/org/OrgAdmin/assets/RequiredIcon';
-import FormController from '@/components/bannerAdmin/form/FormController';
 
 const ContentTypeField = () => {
   const { watch } = useFormContext();

--- a/src/components/bannerAdmin/ContentTypeField.tsx
+++ b/src/components/bannerAdmin/ContentTypeField.tsx
@@ -8,9 +8,12 @@ import {
 } from '@/components/bannerAdmin/CreateBannerModal';
 import { CONTENT_KEY, contentList } from '@/components/bannerAdmin/types/form';
 import RequiredIcon from '@/components/org/OrgAdmin/assets/RequiredIcon';
+import FormController from '@/components/bannerAdmin/form/FormController';
 
 const ContentTypeField = () => {
-  const { register, watch } = useFormContext();
+  const { watch } = useFormContext();
+
+  const content = watch('contentType');
 
   return (
     <StContentWrapper>
@@ -19,14 +22,19 @@ const ContentTypeField = () => {
         <RequiredIcon />
       </StInputLabel>
       <StRadioGroup>
-        {CONTENT_KEY.map((content, index) => (
-          <Radio
-            key={`${index}-${content}`}
-            checked={watch('contentType') === contentList[content]}
-            label={content}
-            size="lg"
-            value={contentList[content]}
-            {...register('contentType')}
+        {CONTENT_KEY.map((contentItem, index) => (
+          <FormController
+            key={`${index}-${contentItem}`}
+            name="contentType"
+            render={({ field }) => (
+              <Radio
+                {...field}
+                label={contentItem}
+                size="lg"
+                value={contentList[contentItem]}
+                checked={content === contentList[contentItem]}
+              />
+            )}
           />
         ))}
       </StRadioGroup>

--- a/src/components/bannerAdmin/CreateBannerModal.tsx
+++ b/src/components/bannerAdmin/CreateBannerModal.tsx
@@ -29,6 +29,8 @@ import { convertUrlToFile } from '@/components/bannerAdmin/utils/converUrlToFile
 import { useEffect, useRef } from 'react';
 import { CREATE_MODAL } from '@/pages/bannerAdmin';
 import { useQueryClient } from 'react-query';
+import { getBannerStatus } from '@/components/bannerAdmin/utils/getBannerStatus';
+import { getBannerType } from '@/components/bannerAdmin/utils/getBannerType';
 
 interface CreateBannerModalProps {
   onCloseModal: () => void;
@@ -159,10 +161,8 @@ const CreateBannerModal = ({
           modalState !== CREATE_MODAL && (
             <Tag
               size="lg"
-              variant={
-                bannerData?.data.status === 'reserved' ? 'primary' : 'secondary'
-              }>
-              {bannerData?.data.status === 'reserved' ? '진행 예정' : '진행 중'}
+              variant={getBannerType(bannerData?.data.status as BANNER_STATUS)}>
+              {getBannerStatus(bannerData?.data.status as BANNER_STATUS)}
             </Tag>
           )
         }

--- a/src/components/bannerAdmin/CreateBannerModal.tsx
+++ b/src/components/bannerAdmin/CreateBannerModal.tsx
@@ -55,6 +55,7 @@ const CreateBannerModal = ({
       contentType: CONTENT_VALUE[0],
       location: LOCATION_VALUE[0],
       dateRange: [],
+      // link: undefined,
     },
     mode: 'onChange',
   });
@@ -111,7 +112,7 @@ const CreateBannerModal = ({
       location: data.location,
       start_date: data.dateRange[0].replaceAll('.', '-'),
       end_date: data.dateRange[1].replaceAll('.', '-'),
-      link: data.link,
+      link: data?.link,
       image_pc: data.pcImageFileName.file,
       image_mobile:
         data.location === 'cr_feed'

--- a/src/components/bannerAdmin/CreateBannerModal.tsx
+++ b/src/components/bannerAdmin/CreateBannerModal.tsx
@@ -3,8 +3,9 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { colors } from '@sopt-makers/colors';
 import { fontsObject } from '@sopt-makers/fonts';
 import { Button, Tag, useToast } from '@sopt-makers/ui';
-
+import { useCallback, useEffect, useRef } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
+import { useQueryClient } from 'react-query';
 
 import BannerImageRegister from '@/components/bannerAdmin/BannerImageRegister';
 import ContentTypeField from '@/components/bannerAdmin/ContentTypeField';
@@ -18,19 +19,17 @@ import {
   CONTENT_VALUE,
   LOCATION_VALUE,
 } from '@/components/bannerAdmin/types/form';
+import { convertUrlToFile } from '@/components/bannerAdmin/utils/converUrlToFile';
+import { getBannerStatus } from '@/components/bannerAdmin/utils/getBannerStatus';
+import { getBannerType } from '@/components/bannerAdmin/utils/getBannerType';
 import ModalFooter from '@/components/common/modal/ModalFooter';
 import ModalHeader from '@/components/common/modal/ModalHeader';
+import { CREATE_MODAL } from '@/pages/bannerAdmin';
 import {
   useGetBannerDetail,
   usePostNewBanner,
   usePutBanner,
 } from '@/services/api/banner/query';
-import { convertUrlToFile } from '@/components/bannerAdmin/utils/converUrlToFile';
-import { useEffect, useRef } from 'react';
-import { CREATE_MODAL } from '@/pages/bannerAdmin';
-import { useQueryClient } from 'react-query';
-import { getBannerStatus } from '@/components/bannerAdmin/utils/getBannerStatus';
-import { getBannerType } from '@/components/bannerAdmin/utils/getBannerType';
 
 interface CreateBannerModalProps {
   onCloseModal: () => void;
@@ -57,7 +56,6 @@ const CreateBannerModal = ({
       contentType: CONTENT_VALUE[0],
       location: LOCATION_VALUE[0],
       dateRange: [],
-      // link: undefined,
     },
     mode: 'onChange',
   });
@@ -68,7 +66,7 @@ const CreateBannerModal = ({
     formState: { isSubmitting, isValid, isDirty, errors },
   } = method;
 
-  const resetData = async () => {
+  const resetData = useCallback(async () => {
     if (!isSuccess || modalState === CREATE_MODAL) {
       return;
     }
@@ -99,7 +97,7 @@ const CreateBannerModal = ({
     });
 
     initialRef.current = false;
-  };
+  }, [bannerData, isSuccess, modalState, reset]);
 
   useEffect(() => {
     if (initialRef.current && isSuccess) {

--- a/src/components/bannerAdmin/CreateBannerModal.tsx
+++ b/src/components/bannerAdmin/CreateBannerModal.tsx
@@ -127,7 +127,7 @@ const CreateBannerModal = ({
           queryClient.invalidateQueries('bannerList');
         },
         onError: () => {
-          open({ icon: 'error', content: '배너를 등록에 실패했어요.' });
+          open({ icon: 'error', content: '배너 등록에 실패했어요.' });
         },
       });
 

--- a/src/components/bannerAdmin/DeleteBannerButton.tsx
+++ b/src/components/bannerAdmin/DeleteBannerButton.tsx
@@ -1,8 +1,8 @@
+import { DialogOptionType, useDialog, useToast } from '@sopt-makers/ui';
 import { useQueryClient } from 'react-query';
 
 import { IcTrash } from '@/assets/icons';
 import { useDeleteBanner } from '@/services/api/banner/query';
-import { DialogOptionType, useDialog, useToast } from '@sopt-makers/ui';
 
 interface DeleteBannerButtonProps {
   bannerId: number;

--- a/src/components/bannerAdmin/DeleteBannerButton.tsx
+++ b/src/components/bannerAdmin/DeleteBannerButton.tsx
@@ -2,7 +2,7 @@ import { useQueryClient } from 'react-query';
 
 import { IcTrash } from '@/assets/icons';
 import { useDeleteBanner } from '@/services/api/banner/query';
-import { DialogOptionType, useDialog } from '@sopt-makers/ui';
+import { DialogOptionType, useDialog, useToast } from '@sopt-makers/ui';
 
 interface DeleteBannerButtonProps {
   bannerId: number;
@@ -15,11 +15,18 @@ const DeleteBannerButton = ({ bannerId }: DeleteBannerButtonProps) => {
 
   const handleBannerDelete = () => {
     deleteBannerMutate(bannerId, {
-      onSuccess: () => queryClient.invalidateQueries('bannerList'),
+      onSuccess: () => {
+        queryClient.invalidateQueries('bannerList');
+        openToast({ icon: 'success', content: '배너가 삭제되었어요.' });
+      },
+      onError: () => {
+        openToast({ icon: 'error', content: '배너 삭제에 실패했어요.' });
+      },
     });
   };
 
-  const { open } = useDialog();
+  const { open: openToast } = useToast();
+  const { open: openDialog } = useDialog();
 
   const option: DialogOptionType = {
     title: '배너를 삭제하실 건가요?',
@@ -33,7 +40,7 @@ const DeleteBannerButton = ({ bannerId }: DeleteBannerButtonProps) => {
   };
 
   return (
-    <button onClick={() => open(option)}>
+    <button onClick={() => openDialog(option)}>
       <IcTrash />
     </button>
   );

--- a/src/components/bannerAdmin/ImageDropZone.tsx
+++ b/src/components/bannerAdmin/ImageDropZone.tsx
@@ -88,7 +88,7 @@ const ImageDropZone = ({
     <StImgButtonWrapper>
       <StImgButton
         {...getRootProps({
-          onClick: handleClick, // input의 클릭 이벤트 핸들링
+          onClick: handleClick,
         })}
         width={width}
         height={height}

--- a/src/components/bannerAdmin/LocationField.tsx
+++ b/src/components/bannerAdmin/LocationField.tsx
@@ -11,7 +11,7 @@ import {
   locationList,
 } from '@/components/bannerAdmin/types/form';
 import RequiredIcon from '@/components/org/OrgAdmin/assets/RequiredIcon';
-import { MutableRefObject, useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 
 import FormController from '@/components/bannerAdmin/form/FormController';
 import { CREATE_MODAL } from '@/pages/bannerAdmin';
@@ -29,23 +29,19 @@ const LocationField = ({ modalState }: LocationField) => {
   useEffect(() => {
     if (modalState === CREATE_MODAL) {
       if (!!pcImageFile?.file && !!mobileImageFile?.file) {
-        console.log(0);
         setValue('pcImageFileName.location', location);
         trigger('pcImageFileName');
         setValue('mobileImageFileName.location', location);
         trigger('mobileImageFileName');
       } else if (!pcImageFile?.file && !!mobileImageFile?.file) {
-        console.log(1);
         setValue('pcImageFileName.location', location);
         setValue('mobileImageFileName.location', location);
         trigger('mobileImageFileName');
       } else if (!!pcImageFile?.file && !mobileImageFile?.file) {
-        console.log(2);
         setValue('pcImageFileName.location', location);
         trigger('pcImageFileName');
         setValue('mobileImageFileName.location', location);
       } else {
-        console.log(3);
         setValue('pcImageFileName.location', location);
         setValue('mobileImageFileName.location', location);
       }

--- a/src/components/bannerAdmin/LocationField.tsx
+++ b/src/components/bannerAdmin/LocationField.tsx
@@ -1,4 +1,5 @@
 import { Radio } from '@sopt-makers/ui';
+import { useEffect } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import {
@@ -6,14 +7,12 @@ import {
   StInputLabel,
   StRadioGroup,
 } from '@/components/bannerAdmin/CreateBannerModal';
+import FormController from '@/components/bannerAdmin/form/FormController';
 import {
   LOCATION_KEY,
   locationList,
 } from '@/components/bannerAdmin/types/form';
 import RequiredIcon from '@/components/org/OrgAdmin/assets/RequiredIcon';
-import { useEffect } from 'react';
-
-import FormController from '@/components/bannerAdmin/form/FormController';
 import { CREATE_MODAL } from '@/pages/bannerAdmin';
 
 interface LocationField {
@@ -51,7 +50,14 @@ const LocationField = ({ modalState }: LocationField) => {
       trigger('pcImageFileName');
       trigger('mobileImageFileName');
     }
-  }, [location]);
+  }, [
+    location,
+    mobileImageFile?.file,
+    modalState,
+    pcImageFile?.file,
+    setValue,
+    trigger,
+  ]);
 
   return (
     <StContentWrapper>

--- a/src/components/bannerAdmin/PublisherField.tsx
+++ b/src/components/bannerAdmin/PublisherField.tsx
@@ -22,8 +22,8 @@ const PublisherField = () => {
         labelText="광고 요청자"
         placeholder="광고 요청자 이름을 입력하세요."
         required={true}
+        maxLength={30}
         {...register('publisher')}
-        isError={!!errors.publisher}
       />
       <StDescriptionWrapper>
         <StDescription isError={!!errors.publisher}>

--- a/src/components/bannerAdmin/form/Calendar/index.tsx
+++ b/src/components/bannerAdmin/form/Calendar/index.tsx
@@ -135,7 +135,7 @@ const CalendarInputForm = ({
     if (selectedDate) {
       setInputValue(dateType === 'endDate' ? selectedDate[1] : selectedDate[0]);
     }
-  }, [selectedDate]);
+  }, [dateType, selectedDate]);
 
   useEffect(() => {
     document.addEventListener('mousedown', handleOutsideClick);

--- a/src/components/bannerAdmin/types/api.ts
+++ b/src/components/bannerAdmin/types/api.ts
@@ -9,7 +9,7 @@ export interface BannerDetailRequest {
   location: (typeof LOCATION_VALUE)[number];
   start_date: string;
   end_date: string;
-  link: string;
+  link?: string;
   image_pc: File;
   image_mobile: File;
 }

--- a/src/components/bannerAdmin/types/form.ts
+++ b/src/components/bannerAdmin/types/form.ts
@@ -1,5 +1,6 @@
-import { getImageSize } from '@/components/bannerAdmin/utils/getImageSize';
 import { z } from 'zod';
+
+import { getImageSize } from '@/components/bannerAdmin/utils/getImageSize';
 
 export const CONTENT_KEY = ['프로덕트 홍보', '기타 홍보', '생일 광고'] as const;
 export const CONTENT_VALUE = ['product', 'etc', 'birthday'] as const;

--- a/src/components/bannerAdmin/types/form.ts
+++ b/src/components/bannerAdmin/types/form.ts
@@ -62,7 +62,11 @@ export const bannerSchema = z.object({
   contentType: z.enum(CONTENT_VALUE),
   location: z.enum(LOCATION_VALUE),
   dateRange: z.string().array(),
-  link: z.string().url({ message: ERROR_MESSAGE.INVALID_LINK }),
+  link: z
+    .string()
+    .url({ message: ERROR_MESSAGE.INVALID_LINK })
+    .optional()
+    .or(z.literal('')),
   pcImageFileName: z
     .object({
       file: z.instanceof(File),

--- a/src/components/bannerAdmin/utils/getBannerStatus.ts
+++ b/src/components/bannerAdmin/utils/getBannerStatus.ts
@@ -1,5 +1,5 @@
 export const getBannerStatus = (bannerStatus: BANNER_STATUS) => {
-  if (bannerStatus === 'reserved') return '진행 예정';
-  if (bannerStatus === 'in_progress') return '진행중';
-  if (bannerStatus === 'done') return '진행 완료';
+  if (bannerStatus === 'RESERVED') return '진행 예정';
+  if (bannerStatus === 'IN_PROGRESS') return '진행중';
+  if (bannerStatus === 'DONE') return '진행 완료';
 };

--- a/src/components/bannerAdmin/utils/getBannerStatus.ts
+++ b/src/components/bannerAdmin/utils/getBannerStatus.ts
@@ -1,0 +1,5 @@
+export const getBannerStatus = (bannerStatus: BANNER_STATUS) => {
+  if (bannerStatus === 'reserved') return '진행 예정';
+  if (bannerStatus === 'in_progress') return '진행중';
+  if (bannerStatus === 'done') return '진행 완료';
+};

--- a/src/components/bannerAdmin/utils/getBannerType.ts
+++ b/src/components/bannerAdmin/utils/getBannerType.ts
@@ -1,5 +1,5 @@
 export const getBannerType = (bannerStatus: BANNER_STATUS) => {
-  if (bannerStatus === 'reserved') return 'primary';
-  if (bannerStatus === 'in_progress') return 'secondary';
-  if (bannerStatus === 'done') return 'default';
+  if (bannerStatus === 'RESERVED') return 'primary';
+  if (bannerStatus === 'IN_PROGRESS') return 'secondary';
+  if (bannerStatus === 'DONE') return 'default';
 };

--- a/src/components/bannerAdmin/utils/getBannerType.ts
+++ b/src/components/bannerAdmin/utils/getBannerType.ts
@@ -1,0 +1,5 @@
+export const getBannerType = (bannerStatus: BANNER_STATUS) => {
+  if (bannerStatus === 'reserved') return 'primary';
+  if (bannerStatus === 'in_progress') return 'secondary';
+  if (bannerStatus === 'done') return 'default';
+};

--- a/src/components/common/modal/ModalHeader/index.tsx
+++ b/src/components/common/modal/ModalHeader/index.tsx
@@ -1,7 +1,8 @@
+import { ReactNode } from 'react';
+
 import { IcModalClose } from '@/assets/icons';
 
 import { StModalHeader } from './style';
-import { ReactNode } from 'react';
 
 interface Props {
   title: string;

--- a/src/hooks/useObserver.ts
+++ b/src/hooks/useObserver.ts
@@ -36,7 +36,7 @@ const useObserver = (props: UseObserver) => {
     }
 
     return () => observer && observer.disconnect();
-  }, [rootMargin, threshold]);
+  }, [onIntersect, root, rootMargin, target, threshold]);
 };
 
 export default useObserver;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -31,7 +31,7 @@ export default function App({ Component, pageProps }: AppProps) {
     if (!getToken('ACCESS')) {
       router.replace('/');
     }
-  }, []);
+  }, [router]);
 
   return (
     <>

--- a/src/pages/bannerAdmin/index.tsx
+++ b/src/pages/bannerAdmin/index.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from 'react';
 
 import CreateBannerModal from '@/components/bannerAdmin/CreateBannerModal';
 import Header from '@/components/bannerAdmin/Header/Header';
-
 import FloatingButton from '@/components/common/FloatingButton';
 import Modal from '@/components/common/modal';
 
@@ -12,6 +11,7 @@ export const CREATE_MODAL = 0;
 
 import { colors } from '@sopt-makers/colors';
 import { fontsObject } from '@sopt-makers/fonts';
+
 import BannerList from '@/components/bannerAdmin/BannerList/BannerList';
 
 const BannerAdminPage = () => {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -32,7 +32,7 @@ function LoginPage() {
     if (getToken('ACCESS')) {
       router.replace('/attendanceAdmin/session');
     }
-  }, []);
+  }, [router]);
 
   const onSubmit = async () => {
     if (state.email && state.password) {

--- a/src/services/api/banner/index.ts
+++ b/src/services/api/banner/index.ts
@@ -1,10 +1,10 @@
+import { AxiosResponse } from 'axios';
+
 import {
   BannerDetailRequest,
   BannerDetailResponse,
 } from '@/components/bannerAdmin/types/api';
 import { client } from '@/services/api/client';
-
-import { AxiosResponse } from 'axios';
 
 export const postNewBanner = async (bannerData: BannerDetailRequest) => {
   const response = await client.post('/banners', bannerData, {

--- a/src/services/api/banner/query.ts
+++ b/src/services/api/banner/query.ts
@@ -1,16 +1,15 @@
 import { useMutation, useQuery } from 'react-query';
 
 import {
-  BannerDetailResponse,
   BannerDetailRequest,
+  BannerDetailResponse,
 } from '@/components/bannerAdmin/types/api';
-
 import {
   deleteBanner,
+  fetchBannerList,
   getBannerDetail,
   postNewBanner,
   putBanner,
-  fetchBannerList,
 } from '@/services/api/banner';
 
 export const usePostNewBanner = () => {

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -15,7 +15,7 @@ declare global {
     | 'DEVELOPER';
   type TARGET_TYPE = 'ALL' | 'ACTIVE' | 'CSV';
   type LINK_TYPE = 'WEB' | 'APP' | 'NONE';
-
+  type BANNER_STATUS = 'reserved' | 'in_progress' | 'done';
   /* 에러 */
   interface LoginError {
     success: boolean;

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -17,7 +17,7 @@ declare global {
     | 'DEVELOPER';
   type TARGET_TYPE = 'ALL' | 'ACTIVE' | 'CSV';
   type LINK_TYPE = 'WEB' | 'APP' | 'NONE';
-  type BANNER_STATUS = 'reserved' | 'in_progress' | 'done';
+
   /* 에러 */
   interface LoginError {
     success: boolean;

--- a/src/utils/translator.tsx
+++ b/src/utils/translator.tsx
@@ -1,5 +1,6 @@
-import CountTag from '@/components/bannerAdmin/CountTag/CountTag';
 import { ReactNode } from 'react';
+
+import CountTag from '@/components/bannerAdmin/CountTag/CountTag';
 export const partList: PART[] = [
   'ALL',
   'PLAN',


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

## ✅ PR Point
1. 배너 삭제시 토스터 생성
2. 링크 인풋 옵셔널 인자로 변경
3. 배너 진행상황에 따른 배너 분기처리
4. 등록자 인풋 30자 제한
5. 라디오 버튼 react-hook-form Controller 로 제어

### react-hook-form control vs register 함수
react-hook-form에서 컴포넌트를 관리하는 방법은 cotrol과 register 두개의 방법이 있어요.

```ts
<Controller
    name="username"
    control={control}
    render={({ field }) => <input {...field} />}
/>
```
이렇게 Controller 컴포넌트를 사용하여 control 프롭으로 값을 관리하는 방법은 제어 컴포넌트를 관리할 수 있어요.
Controller는 외부 라이브러리를 사용할 때 사용하거나, 제어컴포넌트인 경우 사용해야 한다고해요.

```ts
<input {...register('username')} />
```
register로 관리를 하면 이렇게 직접적으로 등록하여 사용해줄 수 있어요. 
해당 경우 비제어로 값을 관리하게 되어 랜더링적으로 효율적이에요.

두 함수의 차이점을 잘 모르고 일단 register로 다 관리하고자 했어요. 하지만 개발자 도구를 킬때마다 `Radio` 버튼에 제어 컴포넌트를 비제어 컴포넌트로 관리해주고 있다고 경고가 떴어요. 이를 확인하고자 MDS의 `Radio` 인풋 코드를 살펴봤어요.

```ts
<input checked={checked} className={radio[size]} ref={ref} type='radio' {...props} />
```
`input` 부분만 가져와봤는데요, 처음에 단순하게 ref가 등록되어 있고 `onChange`가 없어서 비제어 컴포넌트 인줄 알았어요. 
하지만, checked를 보면, checked 값을 props로 받아와서 등록해주는 형태에요. 즉, 외부에서 상태를 주입하여 관리해주기 때문에 제어 컴포넌트의 방식이었어요. 

따라서 해당 `Radio` 컴포넌트도 Control 함수로 관리해줬어요. 사실 MDS의 컴포넌트를 쓰는거 자체가 외부 라이브러리의 컴포넌트를 사용한다는 점에서 control 함수를 사용하는 방식이 더 알맞은 방식이라고 생각할 수 있어요. 

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

## 😭 어려웠던 점

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->
