### PR TITLE
[FEATURE] 배너 어드민 리스트 페이지네이션 적용

### DIFF
--- a/src/assets/icons/IcPaginationLeft.svg
+++ b/src/assets/icons/IcPaginationLeft.svg
@@ -1,0 +1,5 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="pagnation">
+<path id="Vector 3" d="M23 26L17.7071 20.7071C17.3166 20.3166 17.3166 19.6834 17.7071 19.2929L23 14" stroke="#2E2E35" stroke-width="2.5" stroke-linecap="round"/>
+</g>
+</svg>

--- a/src/assets/icons/IcPaginationRight.svg
+++ b/src/assets/icons/IcPaginationRight.svg
@@ -1,0 +1,5 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="pagnation">
+<path id="Vector 3" d="M17 26L22.2929 20.7071C22.6834 20.3166 22.6834 19.6834 22.2929 19.2929L17 14" stroke="#9D9DA4" stroke-width="2.5" stroke-linecap="round"/>
+</g>
+</svg>

--- a/src/assets/icons/index.ts
+++ b/src/assets/icons/index.ts
@@ -8,5 +8,7 @@ export { default as IcGoPrev } from './IcGoPrev.svg';
 export { default as IcModalClose } from './IcModalClose.svg';
 export { default as IcNewDropdown } from './IcNewDropdown.svg';
 export { default as IcOrgMenu } from './IcOrgMenu.svg';
+export { default as IcPaginationLeft } from './IcPaginationLeft.svg';
+export { default as IcPaginationRight } from './IcPaginationRight.svg';
 export { default as IcTrash } from './IcTrash.svg';
 export { default as IcUpload } from './IcUpload.svg';

--- a/src/components/bannerAdmin/BannerList/BannerList.tsx
+++ b/src/components/bannerAdmin/BannerList/BannerList.tsx
@@ -127,7 +127,7 @@ export const StItem = styled.div`
     text-align: left;
   }
 
-  & > p:nth-child(4) {
+  & > p:nth-of-type(4) {
     margin-left: 1rem;
     text-align: center;
   }

--- a/src/components/bannerAdmin/types/api.ts
+++ b/src/components/bannerAdmin/types/api.ts
@@ -35,11 +35,11 @@ export interface BannerListResponse {
   success: boolean;
   message: string;
   data: {
-    banners: Banner[];
+    data: Banner[];
     totalCount: number;
     totalPage: number;
     currentPage: number;
-    hasNextPage: boolean;
-    hasPrevPage: boolean;
   };
+  hasNextPage: boolean;
+  hasPrevPage: boolean;
 }

--- a/src/components/bannerAdmin/types/api.ts
+++ b/src/components/bannerAdmin/types/api.ts
@@ -30,3 +30,16 @@ export interface BannerDetailResponse {
     image_url_mobile: string;
   };
 }
+
+export interface BannerListResponse {
+  success: boolean;
+  message: string;
+  data: {
+    banners: Banner[];
+    totalCount: number;
+    totalPage: number;
+    currentPage: number;
+    hasNextPage: boolean;
+    hasPrevPage: boolean;
+  };
+}

--- a/src/components/bannerAdmin/types/api.ts
+++ b/src/components/bannerAdmin/types/api.ts
@@ -39,7 +39,7 @@ export interface BannerListResponse {
     totalCount: number;
     totalPage: number;
     currentPage: number;
+    hasNextPage: boolean;
+    hasPrevPage: boolean;
   };
-  hasNextPage: boolean;
-  hasPrevPage: boolean;
 }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -24,3 +24,6 @@ export const BANNER_TAB_FILTER_LIST: string[] = [
   '시작날짜 빠른 순',
   '종료날짜 빠른 순',
 ];
+
+export const BANNER_LIST_LIMIT = 20;
+export const BANNER_LIST_PAGE = 1;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -25,6 +25,6 @@ export const BANNER_TAB_FILTER_LIST: string[] = [
   '종료날짜 빠른 순',
 ];
 
-export const BANNER_LIST_LIMIT = 20;
-export const BANNER_LIST_MAX = 1000;
-export const BANNER_LIST_PAGE = 1;
+export const DEFAULT_BANNER_LIST_LIMIT = 20;
+export const DEFAULT_BANNER_LIST_MAX = 1000;
+export const INIT_BANNER_LIST_PAGE = 1;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -26,4 +26,5 @@ export const BANNER_TAB_FILTER_LIST: string[] = [
 ];
 
 export const BANNER_LIST_LIMIT = 20;
+export const BANNER_LIST_MAX = 1000;
 export const BANNER_LIST_PAGE = 1;

--- a/src/pages/bannerAdmin/index.tsx
+++ b/src/pages/bannerAdmin/index.tsx
@@ -4,10 +4,10 @@ import { fontsObject } from '@sopt-makers/fonts';
 import { SelectV2, Tab } from '@sopt-makers/ui';
 import { useEffect, useState } from 'react';
 
+import { IcPaginationLeft, IcPaginationRight } from '@/assets/icons';
 import BannerList from '@/components/bannerAdmin/BannerList/BannerList';
 import CreateBannerModal from '@/components/bannerAdmin/CreateBannerModal';
 import Header from '@/components/bannerAdmin/Header/Header';
-import { IcPaginationLeft, IcPaginationRight } from '@/assets/icons';
 import FloatingButton from '@/components/common/FloatingButton';
 import Modal from '@/components/common/modal';
 import {
@@ -37,6 +37,8 @@ const BannerAdminPage = () => {
     currentPage,
     BANNER_LIST_LIMIT,
   );
+
+  console.log(selectedTabBannerList);
 
   const bannerList = Array.isArray(selectedTabBannerList?.banners)
     ? selectedTabBannerList.banners

--- a/src/pages/bannerAdmin/index.tsx
+++ b/src/pages/bannerAdmin/index.tsx
@@ -23,6 +23,8 @@ import { bannerStatusTranslator } from '@/utils/translator';
 
 const CLOSE_MODAL = -1;
 export const CREATE_MODAL = 0;
+const BACKWARD_PAGE_BUTTON_COUNT = 2;
+const ADDITIONAL_PAGE_BUTTON_COUNT = 4;
 
 const BannerAdminPage = () => {
   const [modalState, setModalState] = useState<number>(CLOSE_MODAL);
@@ -77,11 +79,14 @@ const BannerAdminPage = () => {
 
   const renderPaginationButtons = () => {
     const pageButtons = [];
-    let startPage = Math.max(1, currentPage - 2);
-    let endPage = Math.min(totalPages, startPage + 4);
+    let startPage = Math.max(1, currentPage - BACKWARD_PAGE_BUTTON_COUNT);
+    let endPage = Math.min(
+      totalPages,
+      startPage + ADDITIONAL_PAGE_BUTTON_COUNT,
+    );
 
-    if (endPage - startPage < 4) {
-      startPage = Math.max(1, endPage - 4);
+    if (endPage - startPage < ADDITIONAL_PAGE_BUTTON_COUNT) {
+      startPage = Math.max(1, endPage - ADDITIONAL_PAGE_BUTTON_COUNT);
     }
     for (let i = startPage; i <= endPage; i++) {
       pageButtons.push(

--- a/src/pages/bannerAdmin/index.tsx
+++ b/src/pages/bannerAdmin/index.tsx
@@ -168,12 +168,14 @@ const BannerAdminPage = () => {
           </StBannerListWrapper>
           <StPagination>
             <button
+              type="button"
               onClick={() => handlePageChange(currentPage - 1)}
               disabled={!hasPrevPage}>
               <IcPaginationLeft />
             </button>
             {renderPaginationButtons()}
             <button
+              type="button"
               onClick={() => handlePageChange(currentPage + 1)}
               disabled={!hasNextPage}>
               <IcPaginationRight />

--- a/src/pages/bannerAdmin/index.tsx
+++ b/src/pages/bannerAdmin/index.tsx
@@ -11,10 +11,10 @@ import Header from '@/components/bannerAdmin/Header/Header';
 import FloatingButton from '@/components/common/FloatingButton';
 import Modal from '@/components/common/modal';
 import {
-  BANNER_LIST_LIMIT,
-  BANNER_LIST_MAX,
-  BANNER_LIST_PAGE,
   BANNER_TAB_FILTER_LIST,
+  DEFAULT_BANNER_LIST_LIMIT,
+  DEFAULT_BANNER_LIST_MAX,
+  INIT_BANNER_LIST_PAGE,
 } from '@/constants';
 import { useFetchBannerList } from '@/services/api/banner/query';
 import { getBannerSort, getBannerStatus } from '@/utils';
@@ -30,19 +30,19 @@ const BannerAdminPage = () => {
   const [filter, setFilter] = useState<BANNER_FILTER>(
     BANNER_TAB_FILTER_LIST[0] as BANNER_FILTER,
   );
-  const [currentPage, setCurrentPage] = useState(BANNER_LIST_PAGE);
+  const [currentPage, setCurrentPage] = useState(INIT_BANNER_LIST_PAGE);
 
   const { data: entireBannerList } = useFetchBannerList(
     '',
     'status',
-    BANNER_LIST_PAGE,
-    BANNER_LIST_MAX,
+    INIT_BANNER_LIST_PAGE,
+    DEFAULT_BANNER_LIST_MAX,
   );
   const { data: selectedTabBannerList } = useFetchBannerList(
     getBannerStatus(tab),
     getBannerSort(filter),
     currentPage,
-    BANNER_LIST_LIMIT,
+    DEFAULT_BANNER_LIST_LIMIT,
   );
 
   const bannerList = Array.isArray(selectedTabBannerList?.banners)
@@ -55,12 +55,12 @@ const BannerAdminPage = () => {
 
   const handleChangeTab = (value: BANNER_STATUS) => {
     setTab(value);
-    setCurrentPage(BANNER_LIST_PAGE);
+    setCurrentPage(INIT_BANNER_LIST_PAGE);
   };
 
   const handleSelectFilter = (filter: BANNER_FILTER) => {
     setFilter(filter);
-    setCurrentPage(BANNER_LIST_PAGE);
+    setCurrentPage(INIT_BANNER_LIST_PAGE);
   };
 
   const handlePageChange = (page: number) => {

--- a/src/pages/bannerAdmin/index.tsx
+++ b/src/pages/bannerAdmin/index.tsx
@@ -284,4 +284,9 @@ const StPageButton = styled.button<{ active: boolean }>`
   color: ${({ active }) => (active ? colors.gray950 : colors.gray200)};
 
   ${fontsObject.HEADING_6_18_B};
+
+  &:hover {
+    color: ${colors.white};
+    transition: all 0.2s ease-in;
+  }
 `;

--- a/src/pages/bannerAdmin/index.tsx
+++ b/src/pages/bannerAdmin/index.tsx
@@ -12,6 +12,7 @@ import FloatingButton from '@/components/common/FloatingButton';
 import Modal from '@/components/common/modal';
 import {
   BANNER_LIST_LIMIT,
+  BANNER_LIST_MAX,
   BANNER_LIST_PAGE,
   BANNER_TAB_FILTER_LIST,
 } from '@/constants';
@@ -31,14 +32,18 @@ const BannerAdminPage = () => {
   );
   const [currentPage, setCurrentPage] = useState(BANNER_LIST_PAGE);
 
+  const { data: entireBannerList } = useFetchBannerList(
+    '',
+    'status',
+    BANNER_LIST_PAGE,
+    BANNER_LIST_MAX,
+  );
   const { data: selectedTabBannerList } = useFetchBannerList(
     getBannerStatus(tab),
     getBannerSort(filter),
     currentPage,
     BANNER_LIST_LIMIT,
   );
-
-  console.log(selectedTabBannerList);
 
   const bannerList = Array.isArray(selectedTabBannerList?.banners)
     ? selectedTabBannerList.banners
@@ -111,9 +116,7 @@ const BannerAdminPage = () => {
             style="primary"
             size="md"
             tabItems={BANNER_STATUS_LIST}
-            translator={bannerStatusTranslator(
-              selectedTabBannerList?.banners ?? [],
-            )}
+            translator={bannerStatusTranslator(entireBannerList?.banners ?? [])}
             selectedInitial={tab}
             onChange={handleChangeTab}
             css={{ marginTop: 'auto', gap: '2.6rem' }}

--- a/src/pages/bannerAdmin/index.tsx
+++ b/src/pages/bannerAdmin/index.tsx
@@ -8,7 +8,11 @@ import Header from '@/components/bannerAdmin/Header/Header';
 import { IcPaginationLeft, IcPaginationRight } from '@/assets/icons';
 import FloatingButton from '@/components/common/FloatingButton';
 import Modal from '@/components/common/modal';
-import { BANNER_TAB_FILTER_LIST } from '@/constants';
+import {
+  BANNER_LIST_LIMIT,
+  BANNER_LIST_PAGE,
+  BANNER_TAB_FILTER_LIST,
+} from '@/constants';
 import { useFetchBannerList } from '@/services/api/banner/query';
 import { getBannerSort, getBannerStatus } from '@/utils';
 import { BANNER_STATUS_LIST } from '@/utils/alarm';
@@ -26,15 +30,13 @@ const BannerAdminPage = () => {
   const [filter, setFilter] = useState<BANNER_FILTER>(
     BANNER_TAB_FILTER_LIST[0] as BANNER_FILTER,
   );
-  const [currentPage, setCurrentPage] = useState<number>(1);
-  const limit = 10;
+  const [currentPage, setCurrentPage] = useState(BANNER_LIST_PAGE);
 
-  const { data: entireBannerList } = useFetchBannerList('', 'status');
   const { data: selectedTabBannerList } = useFetchBannerList(
     getBannerStatus(tab),
     getBannerSort(filter),
     currentPage,
-    limit,
+    BANNER_LIST_LIMIT,
   );
 
   const bannerList = Array.isArray(selectedTabBannerList?.banners)
@@ -47,12 +49,12 @@ const BannerAdminPage = () => {
 
   const handleChangeTab = (value: BANNER_STATUS) => {
     setTab(value);
-    setCurrentPage(1);
+    setCurrentPage(BANNER_LIST_PAGE);
   };
 
   const handleSelectFilter = (filter: BANNER_FILTER) => {
     setFilter(filter);
-    setCurrentPage(1);
+    setCurrentPage(BANNER_LIST_PAGE);
   };
 
   const handlePageChange = (page: number) => {
@@ -99,6 +101,8 @@ const BannerAdminPage = () => {
     };
   }, [modalState]);
 
+  console.log(bannerList);
+
   return (
     <>
       <StWrapper>
@@ -108,7 +112,9 @@ const BannerAdminPage = () => {
             style="primary"
             size="md"
             tabItems={BANNER_STATUS_LIST}
-            translator={bannerStatusTranslator(entireBannerList?.banners ?? [])}
+            translator={bannerStatusTranslator(
+              selectedTabBannerList?.banners ?? [],
+            )}
             selectedInitial={tab}
             onChange={handleChangeTab}
             css={{ marginTop: 'auto', gap: '2.6rem' }}
@@ -224,7 +230,9 @@ const StBannerListWrapper = styled.ul`
 
 const StPagination = styled.div`
   display: flex;
+
   margin-top: 2rem;
+
   justify-content: center;
   align-items: center;
   gap: 1.2rem;
@@ -256,7 +264,7 @@ const StPagination = styled.div`
     svg {
       path {
         stroke: ${colors.white};
-        transition: all 0.3s ease;
+        transition: all 0.3s ease-in;
       }
     }
   }

--- a/src/pages/bannerAdmin/index.tsx
+++ b/src/pages/bannerAdmin/index.tsx
@@ -25,19 +25,37 @@ const BannerAdminPage = () => {
   const [filter, setFilter] = useState<BANNER_FILTER>(
     BANNER_TAB_FILTER_LIST[0] as BANNER_FILTER,
   );
+  const [currentPage, setCurrentPage] = useState<number>(1);
+  const limit = 10;
 
   const { data: entireBannerList } = useFetchBannerList('', 'status');
   const { data: selectedTabBannerList } = useFetchBannerList(
     getBannerStatus(tab),
     getBannerSort(filter),
+    currentPage,
+    limit,
   );
+
+  const bannerList = Array.isArray(selectedTabBannerList?.banners)
+    ? selectedTabBannerList.banners
+    : [];
+
+  const totalPages = selectedTabBannerList?.totalPage || 1;
+  const hasNextPage = selectedTabBannerList?.hasNextPage || false;
+  const hasPrevPage = selectedTabBannerList?.hasPrevPage || false;
 
   const handleChangeTab = (value: BANNER_STATUS) => {
     setTab(value);
+    setCurrentPage(1);
   };
 
   const handleSelectFilter = (filter: BANNER_FILTER) => {
     setFilter(filter);
+    setCurrentPage(1);
+  };
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
   };
 
   const handleCloseModal = () => {
@@ -110,9 +128,24 @@ const BannerAdminPage = () => {
           <StBannerListWrapper>
             <BannerList
               onEditModalOpen={handleOpenModal}
-              bannerList={selectedTabBannerList?.banners ?? []}
+              bannerList={bannerList}
             />
           </StBannerListWrapper>
+          <StPagination>
+            <button
+              onClick={() => handlePageChange(currentPage - 1)}
+              disabled={!hasPrevPage}>
+              이전
+            </button>
+            <span>
+              {currentPage} / {totalPages}
+            </span>
+            <button
+              onClick={() => handlePageChange(currentPage + 1)}
+              disabled={!hasNextPage}>
+              다음
+            </button>
+          </StPagination>
         </StBannerList>
       </StWrapper>
       {modalState !== CLOSE_MODAL && (
@@ -165,4 +198,36 @@ const StBannerListWrapper = styled.ul`
 
   flex-direction: column;
   gap: 1rem;
+`;
+
+const StPagination = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 2rem;
+
+  button {
+    padding: 0.5rem 1rem;
+    background-color: ${colors.gray700};
+    border: none;
+    border-radius: 0.5rem;
+    color: ${colors.white};
+    cursor: pointer;
+
+    &:disabled {
+      background-color: ${colors.gray800};
+      color: ${colors.gray500};
+      cursor: not-allowed;
+    }
+
+    &:hover:not(:disabled) {
+      background-color: ${colors.gray600};
+    }
+  }
+
+  span {
+    color: ${colors.white};
+    ${fontsObject.BODY_3_14_M}
+  }
 `;

--- a/src/pages/bannerAdmin/index.tsx
+++ b/src/pages/bannerAdmin/index.tsx
@@ -5,6 +5,7 @@ import BannerList from '@/components/bannerAdmin/BannerList/BannerList';
 import CreateBannerModal from '@/components/bannerAdmin/CreateBannerModal';
 import Header from '@/components/bannerAdmin/Header/Header';
 
+import { IcPaginationLeft, IcPaginationRight } from '@/assets/icons';
 import FloatingButton from '@/components/common/FloatingButton';
 import Modal from '@/components/common/modal';
 import { BANNER_TAB_FILTER_LIST } from '@/constants';
@@ -64,6 +65,27 @@ const BannerAdminPage = () => {
 
   const handleOpenModal = (modalState: number) => {
     setModalState(modalState);
+  };
+
+  const renderPaginationButtons = () => {
+    const pageButtons = [];
+    let startPage = Math.max(1, currentPage - 2);
+    let endPage = Math.min(totalPages, startPage + 4);
+
+    if (endPage - startPage < 4) {
+      startPage = Math.max(1, endPage - 4);
+    }
+    for (let i = startPage; i <= endPage; i++) {
+      pageButtons.push(
+        <StPageButton
+          key={i}
+          onClick={() => handlePageChange(i)}
+          active={i === currentPage}>
+          {i}
+        </StPageButton>,
+      );
+    }
+    return pageButtons;
   };
 
   useEffect(() => {
@@ -135,15 +157,13 @@ const BannerAdminPage = () => {
             <button
               onClick={() => handlePageChange(currentPage - 1)}
               disabled={!hasPrevPage}>
-              이전
+              <IcPaginationLeft />
             </button>
-            <span>
-              {currentPage} / {totalPages}
-            </span>
+            {renderPaginationButtons()}
             <button
               onClick={() => handlePageChange(currentPage + 1)}
               disabled={!hasNextPage}>
-              다음
+              <IcPaginationRight />
             </button>
           </StPagination>
         </StBannerList>
@@ -168,6 +188,8 @@ export default BannerAdminPage;
 
 const StWrapper = styled.div`
   display: flex;
+
+  padding-bottom: 7.2rem;
 
   flex-direction: column;
   gap: 4.9rem;
@@ -202,32 +224,58 @@ const StBannerListWrapper = styled.ul`
 
 const StPagination = styled.div`
   display: flex;
+  margin-top: 2rem;
   justify-content: center;
   align-items: center;
-  gap: 1rem;
-  margin-top: 2rem;
+  gap: 1.2rem;
 
-  button {
-    padding: 0.5rem 1rem;
-    background-color: ${colors.gray700};
-    border: none;
-    border-radius: 0.5rem;
-    color: ${colors.white};
-    cursor: pointer;
-
-    &:disabled {
-      background-color: ${colors.gray800};
-      color: ${colors.gray500};
-      cursor: not-allowed;
-    }
-
-    &:hover:not(:disabled) {
-      background-color: ${colors.gray600};
+  svg {
+    path {
+      stroke: ${colors.gray200};
     }
   }
 
-  span {
-    color: ${colors.white};
-    ${fontsObject.BODY_3_14_M}
+  button:first-of-type {
+    margin-right: 1.2rem;
   }
+
+  button:last-of-type {
+    margin-left: 1.2rem;
+  }
+
+  button:disabled {
+    cursor: not-allowed;
+    svg {
+      path {
+        stroke: ${colors.gray700};
+      }
+    }
+  }
+
+  button:hover:not(:disabled) {
+    svg {
+      path {
+        stroke: ${colors.white};
+        transition: all 0.3s ease;
+      }
+    }
+  }
+`;
+
+const StPageButton = styled.button<{ active: boolean }>`
+  display: flex;
+
+  width: 4rem;
+  height: 4rem;
+  padding: 1.1rem 0.8rem;
+
+  justify-content: center;
+  align-items: center;
+
+  border-radius: 2rem;
+
+  background-color: ${({ active }) => active && colors.gray10};
+  color: ${({ active }) => (active ? colors.gray950 : colors.gray200)};
+
+  ${fontsObject.HEADING_6_18_B};
 `;

--- a/src/pages/bannerAdmin/index.tsx
+++ b/src/pages/bannerAdmin/index.tsx
@@ -101,8 +101,6 @@ const BannerAdminPage = () => {
     };
   }, [modalState]);
 
-  console.log(bannerList);
-
   return (
     <>
       <StWrapper>

--- a/src/services/api/banner/index.ts
+++ b/src/services/api/banner/index.ts
@@ -1,14 +1,11 @@
-import { AxiosResponse } from 'axios';
-
 import {
   BannerDetailRequest,
   BannerDetailResponse,
   BannerListResponse,
 } from '@/components/bannerAdmin/types/api';
+import { BANNER_LIST_LIMIT, BANNER_LIST_PAGE } from '@/constants';
 import { client } from '@/services/api/client';
 import { AxiosResponse } from 'axios';
-
-import { BANNER_LIST_LIMIT, BANNER_LIST_PAGE } from '@/constants';
 
 export const postNewBanner = async (bannerData: BannerDetailRequest) => {
   const response = await client.post('/banners', bannerData, {

--- a/src/services/api/banner/index.ts
+++ b/src/services/api/banner/index.ts
@@ -7,6 +7,8 @@ import { client } from '@/services/api/client';
 
 import { AxiosResponse } from 'axios';
 
+import { BANNER_LIST_LIMIT, BANNER_LIST_PAGE } from '@/constants';
+
 export const postNewBanner = async (bannerData: BannerDetailRequest) => {
   const response = await client.post('/banners', bannerData, {
     headers: {
@@ -47,8 +49,8 @@ export const getBannerDetail = async (bannerId: number) => {
 export const fetchBannerList = async (
   status = '',
   sort = 'status',
-  page = 1,
-  limit = 20,
+  page = BANNER_LIST_PAGE,
+  limit = BANNER_LIST_LIMIT,
 ) => {
   let queryString = '';
 
@@ -64,11 +66,11 @@ export const fetchBannerList = async (
   );
 
   return {
-    banners: data.data.banners,
+    banners: data.data.data,
     totalCount: data.data.totalCount,
     totalPage: data.data.totalPage,
     currentPage: data.data.currentPage,
-    hasNextPage: data.data.hasNextPage,
-    hasPrevPage: data.data.hasPrevPage,
+    hasNextPage: data.hasNextPage,
+    hasPrevPage: data.hasPrevPage,
   };
 };

--- a/src/services/api/banner/index.ts
+++ b/src/services/api/banner/index.ts
@@ -3,7 +3,7 @@ import {
   BannerDetailResponse,
   BannerListResponse,
 } from '@/components/bannerAdmin/types/api';
-import { BANNER_LIST_LIMIT, BANNER_LIST_PAGE } from '@/constants';
+import { DEFAULT_BANNER_LIST_LIMIT, INIT_BANNER_LIST_PAGE } from '@/constants';
 import { client } from '@/services/api/client';
 import { AxiosResponse } from 'axios';
 
@@ -47,8 +47,8 @@ export const getBannerDetail = async (bannerId: number) => {
 export const fetchBannerList = async (
   status = '',
   sort = 'status',
-  page = BANNER_LIST_PAGE,
-  limit = BANNER_LIST_LIMIT,
+  page = INIT_BANNER_LIST_PAGE,
+  limit = DEFAULT_BANNER_LIST_LIMIT,
 ) => {
   let queryString = '';
 

--- a/src/services/api/banner/index.ts
+++ b/src/services/api/banner/index.ts
@@ -1,6 +1,7 @@
 import {
   BannerDetailRequest,
   BannerDetailResponse,
+  BannerListResponse,
 } from '@/components/bannerAdmin/types/api';
 import { client } from '@/services/api/client';
 
@@ -44,18 +45,11 @@ export const getBannerDetail = async (bannerId: number) => {
 };
 
 export const fetchBannerList = async (
-  status: string = '',
-  sort: string = 'status',
-  page: number = 1,
-  limit: number = 10,
-): Promise<{
-  banners: Banner[];
-  totalCount: number;
-  totalPage: number;
-  currentPage: number;
-  hasNextPage: boolean;
-  hasPrevPage: boolean;
-}> => {
+  status = '',
+  sort = 'status',
+  page = 1,
+  limit = 20,
+) => {
   let queryString = '';
 
   if (status) {
@@ -65,24 +59,12 @@ export const fetchBannerList = async (
   queryString += queryString ? `&sort=${sort}` : `?sort=${sort}`;
   queryString += `&page=${page}&limit=${limit}`;
 
-  const {
-    data,
-  }: AxiosResponse<{
-    success: boolean;
-    message: string;
-    data: {
-      limit: number;
-      totalCount: number;
-      totalPage: number;
-      currentPage: number;
-      data: Banner[];
-      hasNextPage: boolean;
-      hasPrevPage: boolean;
-    };
-  }> = await client.get(`/banners${queryString}`);
+  const { data }: AxiosResponse<BannerListResponse> = await client.get(
+    `/banners${queryString}`,
+  );
 
   return {
-    banners: data.data.data,
+    banners: data.data.banners,
     totalCount: data.data.totalCount,
     totalPage: data.data.totalPage,
     currentPage: data.data.currentPage,

--- a/src/services/api/banner/index.ts
+++ b/src/services/api/banner/index.ts
@@ -68,7 +68,7 @@ export const fetchBannerList = async (
     totalCount: data.data.totalCount,
     totalPage: data.data.totalPage,
     currentPage: data.data.currentPage,
-    hasNextPage: data.hasNextPage,
-    hasPrevPage: data.hasPrevPage,
+    hasNextPage: data.data.hasNextPage,
+    hasPrevPage: data.data.hasPrevPage,
   };
 };

--- a/src/services/api/banner/index.ts
+++ b/src/services/api/banner/index.ts
@@ -46,17 +46,16 @@ export const getBannerDetail = async (bannerId: number) => {
 export const fetchBannerList = async (
   status: string = '',
   sort: string = 'status',
-): Promise<{ banners: Banner[]; length: number }> => {
-  if (!status && sort === 'status') {
-    const { data }: AxiosResponse<{ success: boolean; data: Banner[] }> =
-      await client.get('/banners');
-
-    return {
-      banners: data.data,
-      length: data.data.length,
-    };
-  }
-
+  page: number = 1,
+  limit: number = 10,
+): Promise<{
+  banners: Banner[];
+  totalCount: number;
+  totalPage: number;
+  currentPage: number;
+  hasNextPage: boolean;
+  hasPrevPage: boolean;
+}> => {
   let queryString = '';
 
   if (status) {
@@ -64,12 +63,30 @@ export const fetchBannerList = async (
   }
 
   queryString += queryString ? `&sort=${sort}` : `?sort=${sort}`;
+  queryString += `&page=${page}&limit=${limit}`;
 
-  const { data }: AxiosResponse<{ success: boolean; data: Banner[] }> =
-    await client.get(`/banners${queryString}`);
+  const {
+    data,
+  }: AxiosResponse<{
+    success: boolean;
+    message: string;
+    data: {
+      limit: number;
+      totalCount: number;
+      totalPage: number;
+      currentPage: number;
+      data: Banner[];
+      hasNextPage: boolean;
+      hasPrevPage: boolean;
+    };
+  }> = await client.get(`/banners${queryString}`);
 
   return {
-    banners: data.data,
-    length: data.data.length,
+    banners: data.data.data,
+    totalCount: data.data.totalCount,
+    totalPage: data.data.totalPage,
+    currentPage: data.data.currentPage,
+    hasNextPage: data.data.hasNextPage,
+    hasPrevPage: data.data.hasPrevPage,
   };
 };

--- a/src/services/api/banner/query.ts
+++ b/src/services/api/banner/query.ts
@@ -1,5 +1,5 @@
 import { BannerDetailRequest } from '@/components/bannerAdmin/types/api';
-import { BANNER_LIST_LIMIT, BANNER_LIST_PAGE } from '@/constants';
+import { DEFAULT_BANNER_LIST_LIMIT, INIT_BANNER_LIST_PAGE } from '@/constants';
 import { useMutation, useQuery } from 'react-query';
 
 import {
@@ -45,8 +45,8 @@ export const useGetBannerDetail = (bannerId: number) => {
 export const useFetchBannerList = (
   status = '',
   sort = 'status',
-  page = BANNER_LIST_PAGE,
-  limit = BANNER_LIST_LIMIT,
+  page = INIT_BANNER_LIST_PAGE,
+  limit = DEFAULT_BANNER_LIST_LIMIT,
 ) => {
   return useQuery(['bannerList', status, sort, page, limit], () =>
     fetchBannerList(status, sort, page, limit),

--- a/src/services/api/banner/query.ts
+++ b/src/services/api/banner/query.ts
@@ -1,16 +1,13 @@
 import { useMutation, useQuery } from 'react-query';
 
-import {
-  BannerDetailResponse,
-  BannerDetailRequest,
-} from '@/components/bannerAdmin/types/api';
+import { BannerDetailRequest } from '@/components/bannerAdmin/types/api';
 
 import {
   deleteBanner,
+  fetchBannerList,
   getBannerDetail,
   postNewBanner,
   putBanner,
-  fetchBannerList,
 } from '@/services/api/banner';
 
 export const usePostNewBanner = () => {
@@ -48,8 +45,10 @@ export const useGetBannerDetail = (bannerId: number) => {
 export const useFetchBannerList = (
   status: string = '',
   sort: string = 'status',
+  page: number = 1,
+  limit: number = 10,
 ) => {
-  return useQuery(['bannerList', status, sort], () =>
-    fetchBannerList(status, sort),
+  return useQuery(['bannerList', status, sort, page, limit], () =>
+    fetchBannerList(status, sort, page, limit),
   );
 };

--- a/src/services/api/banner/query.ts
+++ b/src/services/api/banner/query.ts
@@ -1,11 +1,6 @@
-import { useMutation, useQuery } from 'react-query';
 import { BannerDetailRequest } from '@/components/bannerAdmin/types/api';
-
 import { BANNER_LIST_LIMIT, BANNER_LIST_PAGE } from '@/constants';
-import {
-  BannerDetailRequest,
-  BannerDetailResponse,
-} from '@/components/bannerAdmin/types/api';
+import { useMutation, useQuery } from 'react-query';
 
 import {
   deleteBanner,

--- a/src/services/api/banner/query.ts
+++ b/src/services/api/banner/query.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery } from 'react-query';
 
 import { BannerDetailRequest } from '@/components/bannerAdmin/types/api';
 
+import { BANNER_LIST_LIMIT, BANNER_LIST_PAGE } from '@/constants';
 import {
   deleteBanner,
   fetchBannerList,
@@ -43,10 +44,10 @@ export const useGetBannerDetail = (bannerId: number) => {
 };
 
 export const useFetchBannerList = (
-  status: string = '',
-  sort: string = 'status',
-  page: number = 1,
-  limit: number = 10,
+  status = '',
+  sort = 'status',
+  page = BANNER_LIST_PAGE,
+  limit = BANNER_LIST_LIMIT,
 ) => {
   return useQuery(['bannerList', status, sort, page, limit], () =>
     fetchBannerList(status, sort, page, limit),

--- a/src/utils/translator.tsx
+++ b/src/utils/translator.tsx
@@ -46,11 +46,13 @@ export const alarmStatusTranslator: Record<ALARM_STATUS, string> = {
 export const bannerStatusTranslator: (
   bannerList: Banner[],
 ) => Record<BANNER_STATUS, ReactNode> = (bannerList) => {
+  const banners = Array.isArray(bannerList) ? bannerList : [];
+
   const countByStatus = {
-    ALL: bannerList.length,
-    RESERVED: bannerList.filter((b) => b.status === 'reserved').length,
-    IN_PROGRESS: bannerList.filter((b) => b.status === 'in_progress').length,
-    DONE: bannerList.filter((b) => b.status === 'done').length,
+    ALL: banners.length,
+    RESERVED: banners.filter((b) => b.status === 'reserved').length,
+    IN_PROGRESS: banners.filter((b) => b.status === 'in_progress').length,
+    DONE: banners.filter((b) => b.status === 'done').length,
   };
 
   const renderTab = (label: string, status: BANNER_STATUS) => (


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

배너 어드민 리스트에서 페이지네이션 기능을 추가해줬어요.

## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->
- 페이지 버튼 (ex, 1, 2, 3 ..)을 리턴해주는 함수를 작성했고, 우선은 해당 로직과 기능이 배너 어드민에서만 쓰이기 때문에 별도로 분리하지 않고 index 파일에 작성했어요.
- svg의 경우 path > stroke 색상을 바꾸는 방식으로 작성해주었어요.

## 😭 어려웠던 점

- 백앤드에서 너무 친절하게도 totalPage, hasNextPage, hasPrevPage와 같은 데이터를 전달해줘서 ,, 큰 이슈는 없었어요 !

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->
