### PR TITLE
[FEATURE] 권한에 따른 라우팅 분리

### DIFF
--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -1,7 +1,6 @@
 import { useRouter } from 'next/router';
 
 import AdminStatusDevtools from '@/components/devTools/AdminStatus';
-import { destroyToken } from '@/utils/auth';
 
 import { StHeader } from './style';
 
@@ -9,7 +8,7 @@ function Header() {
   const router = useRouter();
 
   const logout = () => {
-    destroyToken('ACCESS');
+    sessionStorage.clear();
     router.replace('/');
   };
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -30,7 +30,11 @@ function LoginPage() {
 
   useEffect(() => {
     if (getToken('ACCESS')) {
-      router.replace('/attendanceAdmin/session');
+      router.replace(
+        sessionStorage.getItem('adminStatus') !== 'MAKERS'
+          ? '/attendanceAdmin/session'
+          : '/alarmAdmin',
+      );
     }
   }, [router]);
 


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->
권한에 따라서 라우팅을 다르게 해주었어요.
MAKERS -> 알람 어드민이 초기 화면
SOPT -> 출석 어드민이 초기 화면

또 로그아웃시 세션스토리지에 토큰만 지워지고 권한값은 남아있어서 `sessionStorage.clear()' 메서드로 다 지워주도록 했어요.
## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

## 😭 어려웠던 점

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->
