### PR TITLE
[Fix] 출석 완료 이후 버튼 null 반환

### DIFF
--- a/src/pages/attendanceAdmin/session/[id].tsx
+++ b/src/pages/attendanceAdmin/session/[id].tsx
@@ -214,7 +214,7 @@ function SessionDetailPage() {
     if (res) {
       const result = id && (await updateAttendance(id));
       if (result) {
-        refetchSession();
+        await refetchSession();
         refetchMembers();
         setChangedMembers([]);
         alert('출석 점수가 갱신되었어요');
@@ -232,8 +232,9 @@ function SessionDetailPage() {
         return <>2차 출석 시작하기</>;
       case 'SECOND':
         return <>출석 완료하기</>;
+      case 'END':
       default:
-        return <></>;
+        return null;
     }
   };
 
@@ -370,7 +371,7 @@ function SessionDetailPage() {
       <div ref={bottomRef} />
       {isFetchingNextPage && <Loading dimmed={false} full={false} />}
 
-      {session && session.status !== 'END' && (
+      {session && getButtonContent(session.status) && (
         <>
           {session.status == 'SECOND' && (
             <HelperText


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

출석 완료 이후에도 버튼이 남아있던 문제를 수정했습니다.
-  refetchSession()을 await 처리해 출석 status가 'END'로 갱신된 다음 getButtonContent가 null을 반환하도록 해 버튼이 사라지게 했습니다.


* 와이파이 이슈로 조금 느린 점 감안해주세용

https://github.com/user-attachments/assets/a3cc51c1-5d9b-408f-9aaa-349b1d906764



