### PR TITLE
[Feat] update breakpoint + add useBreakpoint

### DIFF
--- a/src/hooks/useBreakpoint.ts
+++ b/src/hooks/useBreakpoint.ts
@@ -1,0 +1,45 @@
+import { useSyncExternalStore } from 'react';
+
+import { breakpoints } from '@/styles/mediaQuery';
+
+type Breakpoint = 'mobile' | 'tablet' | 'desktop' | 'desktopLarge';
+
+function getBreakpoint(): Breakpoint {
+  const w = window.innerWidth;
+  if (w >= breakpoints.desktopLarge) return 'desktopLarge';
+  if (w >= breakpoints.desktop) return 'desktop';
+  if (w >= breakpoints.tablet) return 'tablet';
+  return 'mobile';
+}
+
+function subscribe(callback: () => void) {
+  const mqls = [
+    window.matchMedia(`(max-width: ${breakpoints.tablet - 1}px)`),
+    window.matchMedia(
+      `(min-width: ${breakpoints.tablet}px) and (max-width: ${breakpoints.desktop - 1}px)`,
+    ),
+    window.matchMedia(
+      `(min-width: ${breakpoints.desktop}px) and (max-width: ${breakpoints.desktopLarge - 1}px)`,
+    ),
+    window.matchMedia(`(min-width: ${breakpoints.desktopLarge}px)`),
+  ];
+  mqls.forEach((m) => m.addEventListener('change', callback));
+  return () => mqls.forEach((m) => m.removeEventListener('change', callback));
+}
+
+export function useBreakpoint() {
+  const bp = useSyncExternalStore(
+    subscribe,
+    getBreakpoint,
+    () => 'desktop' as Breakpoint,
+  );
+
+  return {
+    breakpoint: bp,
+    isMobile: bp === 'mobile',
+    isTablet: bp === 'tablet',
+    isDesktop: bp === 'desktop',
+    isDesktopLarge: bp === 'desktopLarge',
+    isMobileOrTablet: bp === 'mobile' || bp === 'tablet',
+  };
+}

--- a/src/hooks/useBreakpoint.ts
+++ b/src/hooks/useBreakpoint.ts
@@ -1,14 +1,14 @@
 import { useSyncExternalStore } from 'react';
 
-import { breakpoints } from '@/styles/mediaQuery';
-
-type Breakpoint = 'mobile' | 'tablet' | 'desktop' | 'desktopLarge';
+import { Breakpoint, breakpoints } from '@/styles/mediaQuery';
 
 function getBreakpoint(): Breakpoint {
-  const w = window.innerWidth;
-  if (w >= breakpoints.desktopLarge) return 'desktopLarge';
-  if (w >= breakpoints.desktop) return 'desktop';
-  if (w >= breakpoints.tablet) return 'tablet';
+  if (window.matchMedia(`(min-width: ${breakpoints.desktopLarge}px)`).matches)
+    return 'desktopLarge';
+  if (window.matchMedia(`(min-width: ${breakpoints.desktop}px)`).matches)
+    return 'desktop';
+  if (window.matchMedia(`(min-width: ${breakpoints.tablet}px)`).matches)
+    return 'tablet';
   return 'mobile';
 }
 

--- a/src/styles/mediaQuery.ts
+++ b/src/styles/mediaQuery.ts
@@ -1,20 +1,15 @@
-const bp = {
-  mobile: 480,
-  tablet: 1024,
-};
+export const breakpoints = {
+  mobile: 0,
+  tablet: 768,
+  desktop: 1024,
+  desktopLarge: 1260,
+} as const;
 
-const mq = (label: keyof typeof bp) => {
-  const bpArray = Object.keys(bp).map((key) => [
-    key,
-    bp[key as keyof typeof bp],
-  ]);
+export const media = {
+  mobile: `@media (max-width: ${breakpoints.tablet - 1}px)`,
+  tablet: `@media (min-width: ${breakpoints.tablet}px) and (max-width: ${breakpoints.desktop - 1}px)`,
+  desktop: `@media (min-width: ${breakpoints.desktop}px) and (max-width: ${breakpoints.desktopLarge - 1}px)`,
+  desktopLarge: `@media (min-width: ${breakpoints.desktopLarge}px)`,
+} as const;
 
-  const [result] = bpArray.reduce((acc, [name, size]) => {
-    if (label === name) return [...acc, `@media (max-width: ${size}px)`];
-    return acc;
-  }, []);
-
-  return result;
-};
-
-export default mq;
+export type Breakpoint = keyof typeof media;


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

- src/styles/mediaQuery.ts — breakpoints (mobile/tablet/desktop/desktopLarge), media (범위 기반 미디어 쿼리 문자열) 정의
- src/hooks/useBreakpoint.ts — 현재 breakpoint를 반환하는 커스텀 훅 구현

## ✅ PR Point

### 1️⃣ PR Point: useBreakpoint 구현 방식 선택 근거
먼저 해당 훅을 구현하기위해 라이브러리 코드와 기존 makers 팀 (crew) 코드를 비교하고 가장 적합한 코드를 찾으려고 했어요.

1. 기존 crew 방식 (useDisplay)

```ts
const mobile = useMediaQuery({ query: '(max-width: 430px)' }); // react-responsive
  useIsomorphicLayoutEffect(() => {
    setIsMobile(mobile);
}, [mobile]);

```
크루는 breakpoint 하나당 `useMediaQuery + useState + useIsomorphicLayoutEffect` 세트가 반복되는 구조에요. 그리고 next.js를 사용하기에 SSR hydration mismatch를 막기 위해 `useIsomorphicLayoutEffect`를 사용하는 방식을 채택했어요.

<br/>

2. Chakra UI 방식 (useState + useEffect) [코드 링크](https://github.com/chakra-ui/chakra-ui/blob/main/packages/react/src/hooks/use-media-query.ts)


```ts
const [value, setValue] = useState(() => {
  if (!ssr) return { media, matches: window.matchMedia(query).matches }
  return { media: query, matches: !!fallback[index] }
})

useEffect(() => {
  const mql = queries.map((query) => win.matchMedia(query))
  const handler = (evt) => setValue(...)
  const cleanups = mql.map((v) => listen(v, handler))
  return () => cleanups.forEach((fn) => fn())
}, [getWin]) 
```

Chakra UI는 `useState` 초기값으로 SSR/CSR을 분기하고, `useEffect`에서 `matchMedia.addEventListener`로 변화를 구독하는 구조에요.
 

<br/>

  
3. MUI 방식 (useSyncExternalStore) [코드 링크](https://github.com/mui/material-ui/blob/master/packages/mui-system/src/useMediaQuery/useMediaQuery.ts)

```ts
function useMediaQueryNew(...) {
  const [getSnapshot, subscribe] = React.useMemo(() => {
    // matchMedia 구독 등록/해제
  }, [...])

  return maybeReactUseSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
}
```

MUI는 React 18 대응으로 명시적으로 `useSyncExternalStore`로 전환한 것을 확인할 수 있었어요. PR 제목이 "Ensure no tearing in React 18"이더라구요!
[PR 링크](https://github.com/mui/material-ui/pull/28491)
  
>[!NOTE] 
> **useSyncExternalStore와 tearing이란?**
> - tearing: Concurrent Mode(동시성 모드)에서는 렌더링이 중단되고 재개될 수 있다. 그 사이에 외부 스토어가 변경되면 같은 화면에서 컴포넌트마다 서로 다른 데이터를 보여주는 불일치 현상이 발생할 수 있다. 이를 Tearing이라고 한다.
> useState + useEffect 방식은 이를 막을 수 없음. 외부 상태 변화를 effect에서 뒤늦게 반영하기 때문.
>
> - useSyncExternalStore: React가 렌더링 도중에도 외부 스토어의 스냅샷을 동기적으로 확인하여 일관성을 보장. 세 번째 인자 getServerSnapshot으로 SSR 기본값도 명시적으로 선언 가능해 useIsomorphicLayoutEffect 트릭이 필요 없음.

즉 여러 라이브러리와 기존 팀의 코드를 살펴보면 `useEffect/useLayoutEffect + useState`의 조합이거나 MUI와 같이 `useSyncExternalStore`를 쓰는 것을 볼 수 있었어요.

media query 변화는 유저의 브라우저 창 조절 시에만 발생하기 때문에 tearing 실현 가능성 자체는 낮지만 아래와 같은 이유로 MUI와 같은 `useSyncExternalStore` 방식을 채택했어요.

  1. React 18 공식 권장 — 브라우저 API 등 외부 상태 구독에 React 팀이 명시적으로 권장하는 훅 [공식 문서](https://ko.react.dev/reference/react/useSyncExternalStore)
  2. MUI 채택 확인 — 같은 목적(breakpoint 감지)으로 MUI가 실제 마이그레이션 완료
  3. boilerplate 감소 — useState + useIsomorphicLayoutEffect + react-responsive 조합 대신 단일 훅으로 SSR·구독·스냅샷을 통합
  4. 외부 의존성 제거 — react-responsive(라이브러리 > 크루가 사용) 없이 브라우저 표준 window.matchMedia만으로 구현
  5. 이벤트 효율 — resize 이벤트 대신 matchMedia.addEventListener('change') 사용으로 breakpoint 경계를 넘을 때만 콜백 발생

이러한 이유로 `useSyncExternalStore`를 사용한 방식으로 구현했어요.

<br/>

### 2️⃣ PR Point: useBreakpoint 동작
이렇게 구현된 useBreakpoint의 동작을 오약하자면

1. subscribe가 마운트 시 3개 matchMedia에 리스너를 등록하고, 768·1024·1260px 경계를 넘을 때만 React에 알림.
2. React는 알림을 받으면 getBreakpoint를 호출해 matchMedia.matches로 현재 breakpoint를 판단.
3. SSR에서는 window 없으니 세 번째 인자 'desktop'을 기본값으로 반환.

요렇게 돼요! 저도 이 로직은 처음 구현해봐서,,, 정확히 이게 괜찮은지 잘 모르겠습니다,,,
리뷰와 코멘트 너무 환영입니다!!!!!!!!!!!!!!