### PR TITLE
[Feat] 페이지 이탈 방지 로직 추가 및 모달 수정

### DIFF
--- a/src/components/org/OrgAdmin/CommonSection/index.tsx
+++ b/src/components/org/OrgAdmin/CommonSection/index.tsx
@@ -109,12 +109,10 @@ const CommonSectionContent = ({ group, onChangeGroup }: CommonSectionProps) => {
       <BrandingColor isEditable={isEditMode} />
 
       <ActionModal
-        variant="deploy"
         isOpen={isDeployModalOpen}
+        title="배포하시겠습니까?"
         onCancel={() => setEditStep(EDIT_STEP.EDITING)}
         onAction={handleDeploy}
-        alertText="배포하시겠습니까?"
-        description="입력한 공통 설정 내용은 공홈에 즉시 반영돼요."
       />
     </StContainer>
   );

--- a/src/components/org/OrgAdmin/HomeSection/HomeSection.tsx
+++ b/src/components/org/OrgAdmin/HomeSection/HomeSection.tsx
@@ -153,12 +153,10 @@ const HomeSectionContent = () => {
       </StSectionWrapper>
 
       <ActionModal
-        variant="deploy"
         isOpen={isDeployModalOpen}
+        title="배포하시겠습니까?"
         onCancel={() => setEditStep(EDIT_STEP.EDITING)}
         onAction={handleDeploy}
-        alertText="배포하시겠습니까?"
-        description="입력한 홈 탭 내용은 공홈에 즉시 반영돼요."
       />
     </>
   );

--- a/src/components/org/OrgAdmin/HomeSection/_components/News/NewsSection.tsx
+++ b/src/components/org/OrgAdmin/HomeSection/_components/News/NewsSection.tsx
@@ -121,7 +121,9 @@ const NewsSection = ({
       </StNewsModalWrapper>
       <ActionModal
         key={deleteId ?? undefined}
-        variant="delete"
+        variant="danger"
+        title="삭제하시겠습니까?"
+        description="최신 소식은 ‘배포’버튼을 거치지 않고 즉시 배포가 돼요."
         isOpen={deleteId != null}
         onCancel={() => setDeleteId(null)}
         onAction={() => {
@@ -129,8 +131,6 @@ const NewsSection = ({
             handleDeleteNewsItems(deleteId);
           }
         }}
-        alertText="삭제하시겠습니까?"
-        description="최신 소식은 ‘배포’버튼을 거치지 않고 즉시 배포가 돼요."
       />
       <AddNewsModal isOpen={isAddNewsModalOpen} onCancel={closeAddModal} />
       <EditNewsModal

--- a/src/components/org/OrgAdmin/RecruitSection/_components/Faq/index.tsx
+++ b/src/components/org/OrgAdmin/RecruitSection/_components/Faq/index.tsx
@@ -47,14 +47,14 @@ const createDefaultCounts = (): QuestionCounts =>
 
 interface Props {
   isEditable: boolean;
-  resetKey: number;
+  restoreSignal: number;
   fnaPart: PART_KO;
   onChangeFnaPart: (part: PART_KO) => void;
 }
 
 const FaqSection = ({
   isEditable,
-  resetKey,
+  restoreSignal,
   fnaPart,
   onChangeFnaPart,
 }: Props) => {
@@ -92,7 +92,7 @@ const FaqSection = ({
     });
 
     setQuestionCounts(next);
-  }, [data, resetKey]);
+  }, [data, restoreSignal]);
 
   const currentCount = questionCounts[fnaPart];
 

--- a/src/components/org/OrgAdmin/RecruitSection/_components/PartIntroduction/index.tsx
+++ b/src/components/org/OrgAdmin/RecruitSection/_components/PartIntroduction/index.tsx
@@ -51,14 +51,14 @@ const createDefaultPreferenceCounts = (): PreferenceCounts =>
 
 type PartIntroSectionProps = {
   isEditable: boolean;
-  resetKey: number;
+  restoreSignal: number;
   selectedPart: PART_KO;
   onChangePart: (id: PART_KO) => void;
 };
 
 const PartIntroSection = ({
   isEditable,
-  resetKey,
+  restoreSignal,
   selectedPart,
   onChangePart,
 }: PartIntroSectionProps) => {
@@ -104,7 +104,7 @@ const PartIntroSection = ({
     });
 
     setPreferenceCounts(next);
-  }, [data, resetKey]);
+  }, [data, restoreSignal]);
 
   const handleValidation = (field: string, value: string) => {
     if (value) {

--- a/src/components/org/OrgAdmin/RecruitSection/_components/PartIntroduction/index.tsx
+++ b/src/components/org/OrgAdmin/RecruitSection/_components/PartIntroduction/index.tsx
@@ -157,15 +157,6 @@ const PartIntroSection = ({
     syncPreference(nextItems);
   };
 
-  const handleDeletePreferenceItem = (index: number) => {
-    const nextItems = preferenceItems.filter((_, i) => i !== index);
-    syncPreference(nextItems);
-    setPreferenceCounts((prev) => ({
-      ...prev,
-      [selectedPart]: Math.max(prev[selectedPart] - 1, 1),
-    }));
-  };
-
   const textAreaContainerRef = useRef<HTMLDivElement>(null);
 
   // setValue로 채운 값은 onChange를 거치지 않아 자동 높이 계산이 안 되므로 직접 재계산
@@ -185,12 +176,7 @@ const PartIntroSection = ({
     onChangePart(id);
   };
 
-  const oneLineRegister = register(oneLineFieldName, {
-    maxLength: {
-      value: ONE_LINE_MAX_LENGTH,
-      message: ERROR_MESSAGES.oneLine,
-    },
-  });
+  const contentRegister = register(contentFieldName);
 
   return (
     <StSectionWrapper>
@@ -218,7 +204,6 @@ const PartIntroSection = ({
 
           <StTextAreaContainer ref={textAreaContainerRef}>
             <TextArea
-              {...oneLineRegister}
               topAddon={{
                 labelText: '파트 한줄 소개',
                 descriptionText:
@@ -231,8 +216,10 @@ const PartIntroSection = ({
               maxLength={ONE_LINE_MAX_LENGTH}
               value={oneLineValue ?? ''}
               onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
-                oneLineRegister.onChange(e);
-                handleOneLineValidation(e.currentTarget.value);
+                const { value } = e.currentTarget;
+
+                setValue(oneLineFieldName, value, { shouldDirty: true });
+                handleOneLineValidation(value);
               }}
               isError={!!(errors as any)[oneLineFieldName]}
               errorMessage={
@@ -240,7 +227,7 @@ const PartIntroSection = ({
               }
             />
             <StPartIntroductionTextArea
-              {...register(contentFieldName)}
+              {...contentRegister}
               topAddon={{
                 labelText: '이런 걸 배워요',
                 descriptionText:
@@ -250,9 +237,12 @@ const PartIntroSection = ({
               required
               disabled={!isEditable}
               value={contentValue ?? ''}
-              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                handleValidation(contentFieldName, e.currentTarget.value)
-              }
+              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
+                const { value } = e.currentTarget;
+
+                setValue(contentFieldName, value, { shouldDirty: true });
+                handleValidation(contentFieldName, value);
+              }}
               isError={
                 !!(errors as any).recruitPartCurriculum?.[selectedPart]?.content
               }

--- a/src/components/org/OrgAdmin/RecruitSection/_components/PartIntroduction/style.ts
+++ b/src/components/org/OrgAdmin/RecruitSection/_components/PartIntroduction/style.ts
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import { colors } from '@sopt-makers/colors';
 import { TextArea } from '@sopt-makers/ui';
 
 export const StPartIntroductionTextArea = styled(TextArea)`
@@ -20,21 +19,3 @@ export const StPartIntroductionModalWrapper = styled.div`
   right: 0px;
 `;
 
-export const StPreferenceHeader = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-`;
-
-export const StDeleteButton = styled.button`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  color: ${colors.gray300};
-
-  &:hover {
-    color: ${colors.white};
-  }
-`;

--- a/src/components/org/OrgAdmin/RecruitSection/index.tsx
+++ b/src/components/org/OrgAdmin/RecruitSection/index.tsx
@@ -20,13 +20,21 @@ import {
   StRecruitSectionWrapper,
 } from '@/components/org/OrgAdmin/RecruitSection/style';
 import { validationRecruitInputs } from '@/components/org/OrgAdmin/utils';
-import { PART_KO, VALIDATION_CHECK } from '@/utils/org';
+import { PART_KO, PART_LIST, VALIDATION_CHECK } from '@/utils/org';
 
 type SelectedParts = {
   intro: PART_KO;
   curriculum: PART_KO;
   fna: PART_KO;
 };
+
+const RECRUIT_FIELD_NAMES = [
+  'recruitHeaderImage',
+  ...PART_LIST.map((part) => `partIntroduction${part}`),
+  'partCurriculum',
+  'recruitPartCurriculum',
+  'recruitQuestion',
+];
 
 const RecruitSectionContent = () => {
   const [selectedParts, setSelectedParts] = useState<SelectedParts>({
@@ -36,29 +44,23 @@ const RecruitSectionContent = () => {
   });
   const [editStep, setEditStep] = useState<EditStep>(EDIT_STEP.VIEW);
   const [restoreSignal, setRestoreSignal] = useState(0);
+  const [snapshot, setSnapshot] = useState<unknown[] | null>(null);
 
   const { data } = useAdminInfoQuery();
   const { mutate: deployRecruit, isLoading: isDeploying } =
     useDeployRecruitMutation();
 
-  const {
-    control,
-    getValues,
-    setError,
-    setValue,
-    clearErrors,
-    formState: { isDirty },
-  } = useFormContext();
+  const { control, getValues, setError, setValue, clearErrors } =
+    useFormContext();
 
-  const recruitHeaderImage = useWatch({
-    control,
-    name: 'recruitHeaderImage',
-  });
+  const watchedValues = useWatch({ control, name: RECRUIT_FIELD_NAMES });
 
   const isEditMode = editStep !== EDIT_STEP.VIEW;
   const isDeployModalOpen = editStep === EDIT_STEP.DEPLOY;
   const hasUnsavedChanges =
-    isEditMode && (Boolean(recruitHeaderImage?.file) || isDirty);
+    isEditMode &&
+    snapshot !== null &&
+    JSON.stringify(watchedValues) !== JSON.stringify(snapshot);
 
   useEffect(() => {
     syncRecruitFormFromAdminData(data, setValue);
@@ -95,6 +97,11 @@ const RecruitSectionContent = () => {
     setSelectedParts((prev) => ({ ...prev, fna: part }));
   };
 
+  const startEditMode = () => {
+    setSnapshot(JSON.parse(JSON.stringify(getValues(RECRUIT_FIELD_NAMES))));
+    setEditStep(EDIT_STEP.EDITING);
+  };
+
   const exitEditMode = () => {
     setValue('recruitHeaderImage', undefined, {
       shouldDirty: false,
@@ -103,6 +110,7 @@ const RecruitSectionContent = () => {
     clearErrors('recruitHeaderImage');
     syncRecruitFormFromAdminData(data, setValue);
     setRestoreSignal((prev) => prev + 1);
+    setSnapshot(null);
     setEditStep(EDIT_STEP.VIEW);
   };
 
@@ -124,7 +132,7 @@ const RecruitSectionContent = () => {
         isEditMode={isEditMode}
         isDeploying={isDeploying}
         hasUnsavedChanges={hasUnsavedChanges}
-        onStartEdit={() => setEditStep(EDIT_STEP.EDITING)}
+        onStartEdit={startEditMode}
         onCancel={exitEditMode}
         onDeploy={() => {
           if (validateRecruitTabInputs()) {

--- a/src/components/org/OrgAdmin/RecruitSection/index.tsx
+++ b/src/components/org/OrgAdmin/RecruitSection/index.tsx
@@ -147,12 +147,10 @@ const RecruitSectionContent = ({
       </StRecruitSectionWrapper>
 
       <ActionModal
-        variant="deploy"
+        title="배포하시겠습니까?"
         isOpen={isDeployModalOpen}
         onCancel={() => setEditStep(EDIT_STEP.EDITING)}
         onAction={handleDeploy}
-        alertText="배포하시겠습니까?"
-        description="입력한 모집안내 탭 내용은 공홈에 즉시 반영돼요."
       />
     </>
   );

--- a/src/components/org/OrgAdmin/RecruitSection/index.tsx
+++ b/src/components/org/OrgAdmin/RecruitSection/index.tsx
@@ -22,25 +22,20 @@ import {
 import { validationRecruitInputs } from '@/components/org/OrgAdmin/utils';
 import { PART_KO, VALIDATION_CHECK } from '@/utils/org';
 
-interface RecruitSectionProps {
-  introPart: PART_KO;
-  onChangeIntroPart: (part: PART_KO) => void;
-  curriculumPart: PART_KO;
-  onChangeCurriculumPart: (part: PART_KO) => void;
-  fnaPart: PART_KO;
-  onChangeFnaPart: (part: PART_KO) => void;
-}
+type SelectedParts = {
+  intro: PART_KO;
+  curriculum: PART_KO;
+  fna: PART_KO;
+};
 
-const RecruitSectionContent = ({
-  introPart,
-  onChangeIntroPart,
-  curriculumPart,
-  onChangeCurriculumPart,
-  fnaPart,
-  onChangeFnaPart,
-}: RecruitSectionProps) => {
+const RecruitSectionContent = () => {
+  const [selectedParts, setSelectedParts] = useState<SelectedParts>({
+    intro: '기획',
+    curriculum: '기획',
+    fna: '기획',
+  });
   const [editStep, setEditStep] = useState<EditStep>(EDIT_STEP.VIEW);
-  const [resetKey, setResetKey] = useState(0);
+  const [restoreSignal, setRestoreSignal] = useState(0);
 
   const { data } = useAdminInfoQuery();
   const { mutate: deployRecruit, isLoading: isDeploying } =
@@ -88,6 +83,18 @@ const RecruitSectionContent = ({
     );
   };
 
+  const onChangeIntroPart = (part: PART_KO) => {
+    setSelectedParts((prev) => ({ ...prev, intro: part }));
+  };
+
+  const onChangeCurriculumPart = (part: PART_KO) => {
+    setSelectedParts((prev) => ({ ...prev, curriculum: part }));
+  };
+
+  const onChangeFnaPart = (part: PART_KO) => {
+    setSelectedParts((prev) => ({ ...prev, fna: part }));
+  };
+
   const exitEditMode = () => {
     setValue('recruitHeaderImage', undefined, {
       shouldDirty: false,
@@ -95,7 +102,7 @@ const RecruitSectionContent = ({
     });
     clearErrors('recruitHeaderImage');
     syncRecruitFormFromAdminData(data, setValue);
-    setResetKey((prev) => prev + 1);
+    setRestoreSignal((prev) => prev + 1);
     setEditStep(EDIT_STEP.VIEW);
   };
 
@@ -128,20 +135,20 @@ const RecruitSectionContent = ({
       <StRecruitSectionWrapper>
         <HeaderSection isEditable={isEditMode} />
         <PartIntroSection
-          resetKey={resetKey}
+          restoreSignal={restoreSignal}
           isEditable={isEditMode}
-          selectedPart={introPart}
+          selectedPart={selectedParts.intro}
           onChangePart={onChangeIntroPart}
         />
         <CurriculumSection
           isEditable={isEditMode}
-          selectedPart={curriculumPart}
+          selectedPart={selectedParts.curriculum}
           onChangeSelectedPart={onChangeCurriculumPart}
         />
         <FaqSection
-          resetKey={resetKey}
+          restoreSignal={restoreSignal}
           isEditable={isEditMode}
-          fnaPart={fnaPart}
+          fnaPart={selectedParts.fna}
           onChangeFnaPart={onChangeFnaPart}
         />
       </StRecruitSectionWrapper>
@@ -156,11 +163,11 @@ const RecruitSectionContent = ({
   );
 };
 
-const RecruitSection = (props: RecruitSectionProps) => {
+const RecruitSection = () => {
   return (
     <StRecruitContainer>
       <ToastProvider>
-        <RecruitSectionContent {...props} />
+        <RecruitSectionContent />
       </ToastProvider>
     </StRecruitContainer>
   );

--- a/src/components/org/OrgAdmin/_hooks/usePageLeaveBlocker.ts
+++ b/src/components/org/OrgAdmin/_hooks/usePageLeaveBlocker.ts
@@ -1,0 +1,97 @@
+import { useRouter } from 'next/router';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface RouterEventOptions {
+  shallow: boolean;
+}
+
+export const usePageLeaveBlocker = () => {
+  const [blockedRoute, setBlockedRoute] = useState<string | null>(null);
+  const isLeaveAllowedRef = useRef(false);
+
+  const router = useRouter();
+
+  const isPageLeaveModalOpen = blockedRoute !== null;
+
+  const onCancelPageLeave = () => {
+    setBlockedRoute(null);
+  };
+
+  const onLeavePage = () => {
+    if (!blockedRoute) {
+      return;
+    }
+
+    isLeaveAllowedRef.current = true;
+    router.push(blockedRoute);
+  };
+
+  const blockPageLeave = useCallback((url: string) => {
+    setBlockedRoute(url);
+  }, []);
+
+  // 새로고침, 탭 닫기 차단
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, []);
+
+  // 브라우저 뒤로가기/앞으로가기 차단
+  useEffect(() => {
+    router.beforePopState(({ as }) => {
+      if (isLeaveAllowedRef.current || as === router.asPath) {
+        return true;
+      }
+
+      blockPageLeave(as);
+      window.history.pushState(null, '', router.asPath);
+
+      return false;
+    });
+
+    return () => {
+      router.beforePopState(() => true);
+    };
+  }, [blockPageLeave, router, router.asPath]);
+
+  // Next.js 내부 라우트 이동 차단
+  useEffect(() => {
+    const handleRouteChangeStart = (
+      url: string,
+      options: RouterEventOptions,
+    ) => {
+      if (isLeaveAllowedRef.current || url === router.asPath) {
+        return;
+      }
+
+      blockPageLeave(url);
+
+      router.events.emit(
+        'routeChangeError',
+        'Route change cancelled by leave confirm.',
+        url,
+        options,
+      );
+
+      throw new Error('Route change cancelled by leave confirm.');
+    };
+
+    router.events.on('routeChangeStart', handleRouteChangeStart);
+
+    return () => {
+      router.events.off('routeChangeStart', handleRouteChangeStart);
+    };
+  }, [blockPageLeave, router, router.asPath]);
+
+  return {
+    isPageLeaveModalOpen,
+    onCancelPageLeave,
+    onLeavePage,
+  };
+};

--- a/src/components/org/OrgAdmin/common/ActionModal/index.tsx
+++ b/src/components/org/OrgAdmin/common/ActionModal/index.tsx
@@ -1,67 +1,54 @@
-import { CheckBox } from '@sopt-makers/ui';
-import { type HTMLAttributes, useState } from 'react';
+import { type HTMLAttributes } from 'react';
 import type { FieldValues, SubmitHandler } from 'react-hook-form';
 
 import Modal from '@/components/common/modal';
 
 import {
-  StActionButton,
-  StCancelButton,
+  StLeftButton,
   StModalBtnWrapper,
   StModalContainer,
+  StModalContent,
+  StRightButton,
 } from './style';
+
+export type ActionModalVariant = 'default' | 'danger';
 
 interface ActionModalProps extends Omit<HTMLAttributes<HTMLDivElement>, 'id'> {
   isOpen: boolean;
+  title: string;
+  description?: string;
+  variant?: ActionModalVariant;
+  leftButtonText?: string;
+  rightButtonText?: string;
   onCancel?: () => void;
   onAction?: () => void | SubmitHandler<FieldValues>;
-  variant: 'add' | 'delete' | 'deploy';
-  alertText: string;
-  description?: string;
 }
 
 export const ActionModal = ({
   isOpen,
+  title,
+  description,
+  variant = 'default',
+  leftButtonText = '취소',
+  rightButtonText = '확인',
   onCancel,
   onAction,
-  variant,
-  alertText,
-  description,
 }: ActionModalProps) => {
-  const [checked, setChecked] = useState(false);
-
   return (
     isOpen && (
       <Modal>
         <StModalContainer>
-          <h2>{alertText}</h2>
-          <p>{description}</p>
-          <CheckBox
-            label="확인했어요."
-            checked={checked}
-            onChange={() => setChecked((prev) => !prev)}
-          />
+          <StModalContent>
+            <h2>{title}</h2>
+            {description && <p>{description}</p>}
+          </StModalContent>
           <StModalBtnWrapper>
-            <StCancelButton
-              onClick={() => {
-                onCancel && onCancel();
-                setChecked(false);
-              }}>
-              취소
-            </StCancelButton>
-            <StActionButton
-              btntype={variant}
-              disabled={!checked}
-              onClick={() => {
-                setChecked(false);
-                onAction && onAction();
-              }}>
-              {variant === 'add'
-                ? '추가'
-                : variant === 'delete'
-                  ? '삭제'
-                  : '배포'}
-            </StActionButton>
+            <StLeftButton type="button" onClick={() => onCancel?.()}>
+              {leftButtonText}
+            </StLeftButton>
+            <StRightButton btntype={variant} onClick={() => onAction?.()}>
+              {rightButtonText}
+            </StRightButton>
           </StModalBtnWrapper>
         </StModalContainer>
       </Modal>

--- a/src/components/org/OrgAdmin/common/ActionModal/style.ts
+++ b/src/components/org/OrgAdmin/common/ActionModal/style.ts
@@ -3,12 +3,20 @@ import { colors } from '@sopt-makers/colors';
 import { fontsObject } from '@sopt-makers/fonts';
 import { Button } from '@sopt-makers/ui';
 
+import { ActionModalVariant } from '@/components/org/OrgAdmin/common/ActionModal';
+
 export const StModalContainer = styled.div`
+  display: flex;
+  width: 400px;
+  flex-direction: column;
+  gap: 36px;
+  padding: 24px;
+`;
+
+export const StModalContent = styled.div`
   display: flex;
   flex-direction: column;
   gap: 12px;
-
-  padding: 24px;
 
   & > h2 {
     ${fontsObject.TITLE_4_20_SB};
@@ -23,30 +31,68 @@ export const StModalContainer = styled.div`
 `;
 
 export const StModalBtnWrapper = styled.div`
-  place-self: end;
-
   display: flex;
+  justify-content: flex-end;
   gap: 12px;
-
-  padding-top: 24px;
 `;
 
-export const StCancelButton = styled(Button)`
-  background-color: ${colors.gray600};
+export const StLeftButton = styled(Button)`
+  background-color: ${colors.gray700};
   color: ${colors.white};
 
   &:hover {
-    color: ${colors.black};
+    background-color: ${colors.gray600};
+  }
+
+  &:active {
+    background-color: ${colors.gray500};
   }
 `;
 
-export const StActionButton = styled(Button)<{
-  btntype: 'add' | 'delete' | 'deploy';
-}>`
-  color: ${(props) => (props.btntype === 'add' ? colors.black : colors.white)};
+const RIGHT_BUTTON_COLOR_MAP: Record<
+  ActionModalVariant,
+  {
+    color: string;
+    hoverColor: string;
+    backgroundColor: string;
+    hoverBackgroundColor: string;
+    activeBackgroundColor: string;
+  }
+> = {
+  default: {
+    color: colors.black,
+    hoverColor: colors.black,
+    backgroundColor: colors.white,
+    hoverBackgroundColor: colors.gray50,
+    activeBackgroundColor: colors.gray100,
+  },
+  danger: {
+    color: colors.white,
+    hoverColor: colors.white,
+    backgroundColor: colors.error,
+    hoverBackgroundColor: colors.red500,
+    activeBackgroundColor: colors.red600,
+  },
+};
 
-  background-color: ${(props) =>
-    props.btntype === 'add' ? colors.white : colors.error};
+export const StRightButton = styled(Button)<{
+  btntype: ActionModalVariant;
+}>`
+  color: ${({ btntype }) => RIGHT_BUTTON_COLOR_MAP[btntype].color};
+
+  background-color: ${({ btntype }) =>
+    RIGHT_BUTTON_COLOR_MAP[btntype].backgroundColor};
+
+  &:hover {
+    color: ${({ btntype }) => RIGHT_BUTTON_COLOR_MAP[btntype].hoverColor};
+    background-color: ${({ btntype }) =>
+      RIGHT_BUTTON_COLOR_MAP[btntype].hoverBackgroundColor};
+  }
+
+  &:active {
+    background-color: ${({ btntype }) =>
+      RIGHT_BUTTON_COLOR_MAP[btntype].activeBackgroundColor};
+  }
 
   &:disabled {
     cursor: default;

--- a/src/components/org/OrgAdmin/common/Modal/style.ts
+++ b/src/components/org/OrgAdmin/common/Modal/style.ts
@@ -9,6 +9,7 @@ interface StInfoWrapperProps {
 }
 
 export const StInfoWrapper = styled.article<StInfoWrapperProps>`
+  display: ${({ isVisible }) => (isVisible ? 'block' : 'none')};
   width: fit-content;
   position: relative;
   border-radius: 12px;
@@ -17,6 +18,7 @@ export const StInfoWrapper = styled.article<StInfoWrapperProps>`
   transform: ${({ isVisible }) =>
     isVisible ? 'translateX(0)' : 'translateX(100%)'};
   opacity: ${({ isVisible }) => (isVisible ? 1 : 0)};
+  pointer-events: ${({ isVisible }) => (isVisible ? 'auto' : 'none')};
   transition: all 0.5s ease-in-out;
   z-index: ${zIndex.modal};
 `;

--- a/src/components/org/OrgAdmin/index.tsx
+++ b/src/components/org/OrgAdmin/index.tsx
@@ -401,6 +401,7 @@ function OrgAdmin() {
         </form>
       </FormProvider>
       <ActionModal
+        title="배포하시겠습니까?"
         isOpen={isActionModalOpen}
         onCancel={() => {
           setIsActionModalOpen(false);
@@ -409,11 +410,6 @@ function OrgAdmin() {
           setIsActionModalOpen(false);
           // handleSubmit(onSubmit)();
         }}
-        variant="deploy"
-        alertText="배포하시겠습니까?"
-        description={
-          '입력한 내용은 공홈에 즉시 반영돼요.\n잘못 기입된 부분이 없는지 마지막으로 확인해주세요.'
-        }
       />
     </>
   );

--- a/src/components/org/OrgAdmin/index.tsx
+++ b/src/components/org/OrgAdmin/index.tsx
@@ -1,347 +1,36 @@
-import { Button, useToast } from '@sopt-makers/ui';
 import { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
-import {
-  StDevHStack,
-  StListHeader,
-} from '@/components/attendanceAdmin/session/SessionList/style';
+import { StListHeader } from '@/components/attendanceAdmin/session/SessionList/style';
 import FilterButton from '@/components/common/FilterButton';
+import { usePageLeaveBlocker } from '@/components/org/OrgAdmin/_hooks/usePageLeaveBlocker';
 import { EXEC_TYPE, ORG_ADMIN_LIST, PART_KO } from '@/utils/org';
 
 import AboutSection from './AboutSection';
-import SubmitIcon from './assets/SubmitIcon';
 import { ActionModal } from './common/ActionModal';
 import CommonSection from './CommonSection';
 import HomeSection from './HomeSection/HomeSection';
 import RecruitSection from './RecruitSection';
-import { StSubmitButton, StSubmitText } from './style';
 import type { Group } from './types';
-import {
-  validationAboutInputs,
-  validationCommonInputs,
-  validationHomeInputs,
-  validationRecruitInputs,
-} from './utils';
 
 function OrgAdmin() {
-  const [isActionModalOpen, setIsActionModalOpen] = useState(false);
   const [selectedPart, setSelectedPart] = useState<ORG_ADMIN>('공통');
-
   const [group, setGroup] = useState<Group>('OB');
-
   const [selectedPartInHomeTap, setSelectedPartInHomeTap] =
     useState<PART_KO>('기획');
   const [selectedExec, setSelectedExec] = useState<EXEC_TYPE>('회장');
 
-  const [curriculumPart, setCurriculumPart] = useState<PART_KO>('기획');
-  const [fnaPart, setFnaPart] = useState<PART_KO>('기획');
-  const [introPart, setIntroPart] = useState<PART_KO>('기획');
-  const [recruitIntroPart, setRecruitIntroPart] = useState<PART_KO>('기획');
+  const { isPageLeaveModalOpen, onCancelPageLeave, onLeavePage } =
+    usePageLeaveBlocker();
 
   const methods = useForm({ mode: 'onBlur' });
-  const { handleSubmit, getValues, setError, reset, setValue } = methods;
-
-  const { open } = useToast();
-
-  // const { sendMutate, sendIsLoading } = useMutateSendData({
-  //   headerImageFile: getValues('headerImageFileName')?.file,
-  //   coreValueImageFile1: getValues('coreValue1')?.imageFileName?.file,
-  //   coreValueImageFile2: getValues('coreValue2')?.imageFileName?.file,
-  //   coreValueImageFile3: getValues('coreValue3')?.imageFileName?.file,
-  //   memberImageFile1: getValues('member')?.회장?.profileImageFileName?.file,
-  //   memberImageFile2: getValues('member')?.부회장?.profileImageFileName?.file,
-  //   memberImageFile3: getValues('member')?.총무?.profileImageFileName?.file,
-  //   memberImageFile4: getValues('member')?.아트디렉터?.profileImageFileName?.file,
-  //   memberImageFile5:
-  //     getValues('member')?.['운영 팀장']?.profileImageFileName?.file,
-  //   memberImageFile6:
-  //     getValues('member')?.['미디어 팀장']?.profileImageFileName?.file,
-  //   memberImageFile7:
-  //     getValues('member')?.['메이커스 팀장']?.profileImageFileName?.file,
-  //   memberImageFile8: getValues('member')?.기획?.profileImageFileName?.file,
-  //   memberImageFile9: getValues('member')?.디자인?.profileImageFileName?.file,
-  //   memberImageFile10:
-  //     getValues('member')?.안드로이드?.profileImageFileName?.file,
-  //   memberImageFile11: getValues('member')?.iOS?.profileImageFileName?.file,
-  //   memberImageFile12: getValues('member')?.웹?.profileImageFileName?.file,
-  //   memberImageFile13: getValues('member')?.서버?.profileImageFileName?.file,
-  //   recruitHeaderImageFile: getValues('recruitHeaderImage')?.file,
-  // });
 
   const onChangePart = (part: ORG_ADMIN): void => {
     setSelectedPart(part);
   };
 
-  const onChangeIntroPart = (part: PART_KO) => {
-    setIntroPart(part);
-  };
-
-  const handleCheckNonFilledInputs = () => {
-    const handleValidateCommonInputs = () =>
-      validationCommonInputs(getValues, setError, setGroup);
-    const handleValidateHomeInputs = () =>
-      validationHomeInputs(getValues, setError, onChangeIntroPart);
-    const handleValidationAboutInputs = () =>
-      validationAboutInputs(
-        getValues,
-        setError,
-        setSelectedPartInHomeTap,
-        setSelectedExec,
-      );
-    const handleValidationRecruitInputs = () =>
-      validationRecruitInputs(
-        getValues,
-        setError,
-        setCurriculumPart,
-        setFnaPart,
-      );
-
-    const validationFlow = {
-      공통: [
-        handleValidateCommonInputs,
-        handleValidateHomeInputs,
-        handleValidationAboutInputs,
-        handleValidationRecruitInputs,
-      ],
-      홈: [
-        handleValidateHomeInputs,
-        handleValidateCommonInputs,
-        handleValidationAboutInputs,
-        handleValidationRecruitInputs,
-      ],
-      소개: [
-        handleValidationAboutInputs,
-        handleValidateCommonInputs,
-        handleValidateHomeInputs,
-        handleValidationRecruitInputs,
-      ],
-      모집안내: [
-        handleValidationRecruitInputs,
-        handleValidateCommonInputs,
-        handleValidateHomeInputs,
-        handleValidationAboutInputs,
-      ],
-    };
-
-    const validationSequence = validationFlow[selectedPart];
-
-    const getPartForValidation = (validateFn: () => boolean) => {
-      if (validateFn === handleValidateCommonInputs) return '공통';
-      if (validateFn === handleValidationAboutInputs) return '소개';
-      if (validateFn === handleValidationRecruitInputs) return '모집안내';
-      if (validateFn === handleValidateHomeInputs) return '홈';
-      return '공통';
-    };
-
-    for (const validate of validationSequence) {
-      const isValid = validate();
-
-      if (!isValid) {
-        open({
-          icon: 'error',
-          content: `${getPartForValidation(validate)}탭에 아직 채우지 않은 필드가 있어요.`,
-        });
-        setSelectedPart(getPartForValidation(validate));
-        return false;
-      }
-    }
-
-    return true;
-  };
-
-  // const onSubmit: SubmitHandler<FieldValues> = (data) => {
-  //   const {
-  //     generation,
-  //     brandingColor,
-  //     coreValue1,
-  //     coreValue2,
-  //     coreValue3,
-  //     headerImageFileName,
-  //     member,
-  //     name,
-  //     partCurriculum,
-  //     partIntroductioniOS,
-  //     partIntroduction기획,
-  //     partIntroduction디자인,
-  //     partIntroduction서버,
-  //     partIntroduction안드로이드,
-  //     partIntroduction웹,
-  //     recruitHeaderImage,
-  //     recruitPartCurriculum,
-  //     recruitQuestion,
-  //     recruitSchedule,
-  //   } = data;
-  //   const requestBody: AddAdminRequestDto = {
-  //     generation: Number(generation),
-  //     name,
-  //     recruitSchedule: [
-  //       {
-  //         type: 'OB',
-  //         schedule: recruitSchedule.OB,
-  //       },
-  //       {
-  //         type: 'YB',
-  //         schedule: recruitSchedule.YB,
-  //       },
-  //     ],
-  //     brandingColor,
-  //     mainButton: {
-  //       text: '지원하기',
-  //       keyColor: '#FF0000',
-  //       subColor: '#CC0000',
-  //     },
-  //     partIntroduction: [
-  //       {
-  //         part: '기획',
-  //         description: partIntroduction기획,
-  //       },
-  //       {
-  //         part: '디자인',
-  //         description: partIntroduction디자인,
-  //       },
-  //       {
-  //         part: '서버',
-  //         description: partIntroduction서버,
-  //       },
-  //       {
-  //         part: '웹',
-  //         description: partIntroduction웹,
-  //       },
-  //       {
-  //         part: '안드로이드',
-  //         description: partIntroduction안드로이드,
-  //       },
-  //       {
-  //         part: 'iOS',
-  //         description: partIntroductioniOS,
-  //       },
-  //     ],
-  //     headerImageFileName: headerImageFileName.fileName,
-  //     coreValue: [
-  //       {
-  //         ...coreValue1,
-  //         imageFileName: coreValue1.imageFileName.fileName,
-  //       },
-  //       {
-  //         ...coreValue2,
-  //         imageFileName: coreValue2.imageFileName.fileName,
-  //       },
-  //       {
-  //         ...coreValue3,
-  //         imageFileName: coreValue3.imageFileName.fileName,
-  //       },
-  //     ],
-  //     partCurriculum: PART_LIST.map((part) => ({
-  //       part,
-  //       curriculums: partCurriculum[part],
-  //     })),
-  //     member: [...임원진_LIST, ...PART_LIST]
-  //       .filter(
-  //         (exec) => member && member[exec] && member[exec].profileImageFileName,
-  //       )
-  //       .map((exec) => ({
-  //         role: exec,
-  //         ...member[exec],
-  //         profileImageFileName: member[exec].profileImageFileName.fileName,
-  //       })),
-  //     recruitHeaderImageFileName: recruitHeaderImage.fileName,
-  //     recruitPartCurriculum: PART_LIST.map((part) => ({
-  //       part,
-  //       introduction: recruitPartCurriculum[part],
-  //     })),
-  //     recruitQuestion: PART_LIST.map((part) => ({
-  //       part,
-  //       questions: [
-  //         {
-  //           question: recruitQuestion[part].question0,
-  //           answer: recruitQuestion[part].answer0,
-  //         },
-  //         {
-  //           question: recruitQuestion[part].question1,
-  //           answer: recruitQuestion[part].answer1,
-  //         },
-  //         {
-  //           question: recruitQuestion[part].question2,
-  //           answer: recruitQuestion[part].answer2,
-  //         },
-  //       ],
-  //     })),
-  //   };
-
-  //   sendMutate(requestBody);
-  // };
-
-  const handleClickMagicButton = (type: 'SET' | 'GET' | 'IMAGE' | 'RESET') => {
-    if (type === 'SET') {
-      localStorage.setItem('org-admin', JSON.stringify(getValues()));
-      alert('데이터 임시저장 성공!');
-      return;
-    }
-    if (type === 'GET') {
-      const data = localStorage.getItem('org-admin');
-      if (!data) {
-        alert('저장된 데이터가 없음ㅠ');
-      } else {
-        reset(JSON.parse(data));
-        alert(
-          '데이터 불러오기 성공! \n소개탭 헤더를 반드시 다시 첨부해주세요!',
-        );
-      }
-      return;
-    }
-
-    if (type === 'IMAGE') {
-      const headerImage = getValues('headerImageFileName');
-      if (!(headerImage?.file instanceof File)) {
-        alert('소개탭 헤더 넣어주세용');
-        return;
-      }
-      setValue('coreValue1.imageFileName', headerImage);
-      setValue('coreValue2.imageFileName', headerImage);
-      setValue('coreValue3.imageFileName', headerImage);
-      setValue('member.회장.profileImageFileName', headerImage);
-      setValue('member.부회장.profileImageFileName', headerImage);
-      setValue('member.총무.profileImageFileName', headerImage);
-      setValue('member.아트디렉터.profileImageFileName', headerImage);
-      setValue('member.운영 팀장.profileImageFileName', headerImage);
-      setValue('member.미디어 팀장.profileImageFileName', headerImage);
-      setValue('member.메이커스 팀장.profileImageFileName', headerImage);
-      setValue('member.기획.profileImageFileName', headerImage);
-      setValue('member.디자인.profileImageFileName', headerImage);
-      setValue('member.안드로이드.profileImageFileName', headerImage);
-      setValue('member.iOS.profileImageFileName', headerImage);
-      setValue('member.웹.profileImageFileName', headerImage);
-      setValue('member.서버.profileImageFileName', headerImage);
-      setValue('recruitHeaderImage', headerImage);
-
-      alert('소개탭 헤더로 이미지 밀기 성공!');
-      return;
-    }
-    localStorage.removeItem('org-admin');
-
-    alert('데이터 초기화 성공! 새로고침하세용');
-  };
   return (
     <>
-      {process.env.NEXT_PUBLIC_API_URL !== 'PRODUCTION' && (
-        <StDevHStack>
-          <p>매직버튼</p>
-          <Button size="sm" onClick={() => handleClickMagicButton('SET')}>
-            임시저장
-          </Button>
-          <Button size="sm" onClick={() => handleClickMagicButton('GET')}>
-            불러오기
-          </Button>
-          <Button size="sm" onClick={() => handleClickMagicButton('IMAGE')}>
-            이미지 채우기
-          </Button>
-          <Button size="sm" onClick={() => handleClickMagicButton('RESET')}>
-            데이터삭제
-          </Button>
-        </StDevHStack>
-      )}
-
       <StListHeader>
         <h1>공홈 관리</h1>
         <FilterButton
@@ -373,43 +62,20 @@ function OrgAdmin() {
               }
             />
           ) : (
-            <RecruitSection
-              introPart={recruitIntroPart}
-              onChangeIntroPart={(part: PART_KO) => setRecruitIntroPart(part)}
-              curriculumPart={curriculumPart}
-              onChangeCurriculumPart={(part: PART_KO) =>
-                setCurriculumPart(part)
-              }
-              fnaPart={fnaPart}
-              onChangeFnaPart={(part: PART_KO) => setFnaPart(part)}
-            />
+            <RecruitSection />
           )}
-          {selectedPart !== '홈' &&
-            selectedPart !== '모집안내' &&
-            selectedPart !== '공통' && (
-              <StSubmitButton
-                type="button"
-                onClick={() => {
-                  if (handleCheckNonFilledInputs()) {
-                    setIsActionModalOpen(true);
-                  }
-                }}>
-                <SubmitIcon />
-                <StSubmitText>배포</StSubmitText>
-              </StSubmitButton>
-            )}
         </form>
       </FormProvider>
+
       <ActionModal
-        title="배포하시겠습니까?"
-        isOpen={isActionModalOpen}
-        onCancel={() => {
-          setIsActionModalOpen(false);
-        }}
-        onAction={() => {
-          setIsActionModalOpen(false);
-          // handleSubmit(onSubmit)();
-        }}
+        title="페이지를 나가시겠습니까?"
+        description="배포되지 않은 변경사항은 사라집니다."
+        isOpen={isPageLeaveModalOpen}
+        variant="danger"
+        leftButtonText="취소"
+        rightButtonText="나가기"
+        onCancel={onCancelPageLeave}
+        onAction={onLeavePage}
       />
     </>
   );


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

페이지 이탈 방지 모달 추가 & ActionModal variant 및 레이아웃 수정

## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

1. 페이지 이탈 / 새로고침 / 내부 라우트를 차단하는 `usePageLeaveBlocker`를 추가했습니다.

- 앱 내부의 이동은 routeChangeStart에서 감지하고, 브라우저 상에서 뒤로 가거나 앞으로 가는 동작은 router.beforePopState로 감지합니다.
- 새로고침이나 탭을 닫을 땐 브라우저의 beforeunload 이벤트를 통해 막습니다.


2. ActionModal 

- ActionModal의 경우 한 번 더 confirm하는 체크박스가 존재했는데, 단순화돼서 해당 부분을 삭제했고, 사용되지 않는 Variant를 지웠습니다.

3. 우측 정보 모달로 인해 본문 내용 포커싱 안되는 이슈

- 어드민에서 정보 버튼을 누르면 우측에서 등장하는 모달이 등장하지 않을 때에도 영역이 잡히는 이슈가 있었습니다.
- 모달 상태에 따라 pointer-events 속성과 display속성을 추가하여 수정했습니다.