### PR TITLE
[Fix] 2차 스프린트 QA 반영

### DIFF
--- a/src/components/org/OrgAdmin/AboutSection/index.tsx
+++ b/src/components/org/OrgAdmin/AboutSection/index.tsx
@@ -23,11 +23,13 @@ import Schedule from './Schedule';
 interface AboutSectionProps {
   selectedExec: EXEC_TYPE;
   onChangeSelectedExec: (member: EXEC_TYPE) => void;
+  onEditModeChange: (isEditing: boolean) => void;
 }
 
 const AboutSectionContent = ({
   selectedExec,
   onChangeSelectedExec,
+  onEditModeChange,
 }: AboutSectionProps) => {
   const [editStep, setEditStep] = useState<EditStep>(EDIT_STEP.VIEW);
 
@@ -46,6 +48,10 @@ const AboutSectionContent = ({
   const isEditMode = editStep !== EDIT_STEP.VIEW;
   const isDeployModalOpen = editStep === EDIT_STEP.DEPLOY;
   const hasUnsavedChanges = isEditMode && isDirty;
+
+  useEffect(() => {
+    onEditModeChange(isEditMode);
+  }, [isEditMode, onEditModeChange]);
 
   useEffect(() => {
     syncAboutFormFromAdminData(data, setValue);

--- a/src/components/org/OrgAdmin/AboutSection/index.tsx
+++ b/src/components/org/OrgAdmin/AboutSection/index.tsx
@@ -41,6 +41,7 @@ const AboutSectionContent = ({
     getValues,
     setValue,
     setError,
+    setFocus,
     clearErrors,
     formState: { isDirty },
   } = useFormContext();
@@ -85,6 +86,8 @@ const AboutSectionContent = ({
             validationAboutInputs(
               getValues,
               setError,
+              setFocus,
+              onChangeSelectedExec,
               data?.headerImage,
               data?.coreValue,
               data?.member,

--- a/src/components/org/OrgAdmin/CommonSection/index.tsx
+++ b/src/components/org/OrgAdmin/CommonSection/index.tsx
@@ -44,7 +44,7 @@ const CommonSectionContent = ({
   const { mutate: deployCommon, isLoading: isDeploying } =
     useDeployCommonMutation();
 
-  const { control, getValues, setValue, setError, clearErrors } =
+  const { control, getValues, setValue, setError, setFocus, clearErrors } =
     useFormContext();
 
   const watchedValues = useWatch({ control, name: COMMON_FIELD_NAMES });
@@ -104,7 +104,9 @@ const CommonSectionContent = ({
         onStartEdit={startEditMode}
         onCancel={cancelEditMode}
         onDeploy={() => {
-          if (validationCommonInputs(getValues, setError, onChangeGroup)) {
+          if (
+            validationCommonInputs(getValues, setError, setFocus, onChangeGroup)
+          ) {
             setEditStep(EDIT_STEP.DEPLOY);
           }
         }}

--- a/src/components/org/OrgAdmin/CommonSection/index.tsx
+++ b/src/components/org/OrgAdmin/CommonSection/index.tsx
@@ -22,6 +22,7 @@ import RecruitSchedule from './RecruitSchedule';
 interface CommonSectionProps {
   group: Group;
   onChangeGroup: (group: Group) => void;
+  onEditModeChange: (isEditing: boolean) => void;
 }
 
 const COMMON_FIELD_NAMES = [
@@ -31,7 +32,11 @@ const COMMON_FIELD_NAMES = [
   'brandingColor',
 ];
 
-const CommonSectionContent = ({ group, onChangeGroup }: CommonSectionProps) => {
+const CommonSectionContent = ({
+  group,
+  onChangeGroup,
+  onEditModeChange,
+}: CommonSectionProps) => {
   const [editStep, setEditStep] = useState<EditStep>(EDIT_STEP.VIEW);
   const [snapshot, setSnapshot] = useState<unknown[] | null>(null);
 
@@ -50,6 +55,10 @@ const CommonSectionContent = ({ group, onChangeGroup }: CommonSectionProps) => {
     isEditMode &&
     snapshot !== null &&
     JSON.stringify(watchedValues) !== JSON.stringify(snapshot);
+
+  useEffect(() => {
+    onEditModeChange(isEditMode);
+  }, [isEditMode, onEditModeChange]);
 
   useEffect(() => {
     syncCommonFormFromAdminData(data, setValue);

--- a/src/components/org/OrgAdmin/HomeSection/HomeSection.tsx
+++ b/src/components/org/OrgAdmin/HomeSection/HomeSection.tsx
@@ -34,7 +34,11 @@ type HomeDraft = {
 const EMPTY_REVIEWS: Review[] = [];
 const EMPTY_NEWS: News[] = [];
 
-const HomeSectionContent = () => {
+interface HomeSectionProps {
+  onEditModeChange: (isEditing: boolean) => void;
+}
+
+const HomeSectionContent = ({ onEditModeChange }: HomeSectionProps) => {
   const [editStep, setEditStep] = useState<EditStep>(EDIT_STEP.VIEW);
   const [draft, setDraft] = useState<HomeDraft>({
     reviews: EMPTY_REVIEWS,
@@ -73,9 +77,14 @@ const HomeSectionContent = () => {
   };
 
   const hasUnsavedChanges =
-    Boolean(homeHeaderImage?.file) ||
-    !isSameOrder(initialReviews, draft.reviews) ||
-    !isSameOrder(latestNews, draft.news);
+    isEditMode &&
+    (Boolean(homeHeaderImage?.file) ||
+      !isSameOrder(initialReviews, draft.reviews) ||
+      !isSameOrder(latestNews, draft.news));
+
+  useEffect(() => {
+    onEditModeChange(isEditMode);
+  }, [isEditMode, onEditModeChange]);
 
   const validateHomeInputs = () => {
     const { homeHeaderImageFileName } = getValues();
@@ -162,11 +171,11 @@ const HomeSectionContent = () => {
   );
 };
 
-const HomeSection = () => {
+const HomeSection = (props: HomeSectionProps) => {
   return (
     <StContainer>
       <ToastProvider>
-        <HomeSectionContent />
+        <HomeSectionContent {...props} />
       </ToastProvider>
     </StContainer>
   );

--- a/src/components/org/OrgAdmin/HomeSection/HomeSection.tsx
+++ b/src/components/org/OrgAdmin/HomeSection/HomeSection.tsx
@@ -52,7 +52,7 @@ const HomeSectionContent = ({ onEditModeChange }: HomeSectionProps) => {
 
   const initialReviews = reviewsData ?? EMPTY_REVIEWS;
   const latestNews = data?.latestNews ?? EMPTY_NEWS;
-  const { control, getValues, setError, setValue, clearErrors } =
+  const { control, getValues, setError, setFocus, setValue, clearErrors } =
     useFormContext();
   const homeHeaderImage = useWatch({
     control,
@@ -94,6 +94,7 @@ const HomeSectionContent = ({ onEditModeChange }: HomeSectionProps) => {
         type: 'required',
         message: VALIDATION_CHECK.required.errorText,
       });
+      setFocus('homeHeaderImageFileName');
       return false;
     }
 

--- a/src/components/org/OrgAdmin/MyDropzone/index.tsx
+++ b/src/components/org/OrgAdmin/MyDropzone/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { type MouseEvent, useCallback } from 'react';
+import { type MouseEvent, type MutableRefObject, useCallback } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { type UseFormReturn, useWatch } from 'react-hook-form';
 
@@ -78,7 +78,7 @@ const MyDropzone = ({
     e.preventDefault();
   };
 
-  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+  const { getRootProps, getInputProps, inputRef, isDragActive } = useDropzone({
     onDrop,
     disabled,
     accept: {
@@ -87,6 +87,27 @@ const MyDropzone = ({
       'image/png': [],
     },
   });
+  const { ref: formRef, ...formInputProps } = register(label, {
+    validate: (value) => {
+      if (!required) {
+        return true;
+      }
+
+      if (value?.fileName || defaultPreviewUrl) {
+        return true;
+      }
+
+      return VALIDATION_CHECK.required.errorText;
+    },
+  });
+  const dropzoneInputProps = getInputProps();
+  const setInputRef = useCallback(
+    (element: HTMLInputElement | null) => {
+      formRef(element);
+      (inputRef as MutableRefObject<HTMLInputElement | null>).current = element;
+    },
+    [formRef, inputRef],
+  );
 
   return (
     <StImgButtonWrapper>
@@ -100,20 +121,9 @@ const MyDropzone = ({
         isError={errorMsg}
         isDisabled={disabled}>
         <input
-          {...register(label, {
-            validate: (value) => {
-              if (!required) {
-                return true;
-              }
-
-              if (value?.fileName || defaultPreviewUrl) {
-                return true;
-              }
-
-              return VALIDATION_CHECK.required.errorText;
-            },
-          })}
-          {...getInputProps()}
+          {...formInputProps}
+          {...dropzoneInputProps}
+          ref={setInputRef}
           disabled={disabled}
         />
         {previewUrl ? (

--- a/src/components/org/OrgAdmin/RecruitSection/_components/Curriculum/index.tsx
+++ b/src/components/org/OrgAdmin/RecruitSection/_components/Curriculum/index.tsx
@@ -3,6 +3,7 @@ import { useFormContext } from 'react-hook-form';
 
 import Modal from '@/components/org/OrgAdmin/common/Modal';
 import useModal from '@/components/org/OrgAdmin/common/Modal/useModal';
+import { CURRICULUM_WEEK_COUNT } from '@/components/org/OrgAdmin/RecruitSection/_constants/constants';
 import { PART_KO, PART_LIST, VALIDATION_CHECK } from '@/utils/org';
 
 import { StInput, StTitle, StWrapper } from '../../../AboutSection/style';
@@ -17,7 +18,7 @@ import { StItem, StList, StWeek } from './style';
 
 const CURRICULUM = PART_LIST.reduce(
   (acc, part) => {
-    acc[part] = Array.from({ length: 8 });
+    acc[part] = Array.from({ length: CURRICULUM_WEEK_COUNT });
     return acc;
   },
   {} as Record<string, string[]>,

--- a/src/components/org/OrgAdmin/RecruitSection/_components/PartIntroduction/index.tsx
+++ b/src/components/org/OrgAdmin/RecruitSection/_components/PartIntroduction/index.tsx
@@ -177,6 +177,8 @@ const PartIntroSection = ({
   };
 
   const contentRegister = register(contentFieldName);
+  const oneLineRegister = register(oneLineFieldName);
+  const preferenceRegister = register(preferenceFieldName);
 
   return (
     <StSectionWrapper>
@@ -204,6 +206,7 @@ const PartIntroSection = ({
 
           <StTextAreaContainer ref={textAreaContainerRef}>
             <TextArea
+              {...oneLineRegister}
               topAddon={{
                 labelText: '파트 한줄 소개',
                 descriptionText:
@@ -252,6 +255,7 @@ const PartIntroSection = ({
             {preferenceItems.map((item, index) => (
               <StPreferenceItem key={index}>
                 <StPartIntroductionTextArea
+                  ref={index === 0 ? preferenceRegister.ref : undefined}
                   topAddon={
                     index === 0
                       ? {

--- a/src/components/org/OrgAdmin/RecruitSection/_constants/constants.ts
+++ b/src/components/org/OrgAdmin/RecruitSection/_constants/constants.ts
@@ -7,5 +7,6 @@ export const ERROR_MESSAGES = {
 
 export const PREFERENCE_DEFAULT_COUNT = 3;
 export const PREFERENCE_MAX_COUNT = 10;
+export const CURRICULUM_WEEK_COUNT = 8;
 export const ONE_LINE_MAX_LENGTH = 50;
 export const ONE_LINE_MAX_LENGTH_ERROR_MESSAGE = '50자 이내로 입력해 주세요.';

--- a/src/components/org/OrgAdmin/RecruitSection/api.ts
+++ b/src/components/org/OrgAdmin/RecruitSection/api.ts
@@ -1,16 +1,12 @@
 import type { FieldValues } from 'react-hook-form';
 
 import type { AddAdminRecruitRequestDto } from '@/__generated__/org-types/data-contracts';
-import {
-  extractFileNameFromUrl,
-  uploadToS3,
-} from '@/components/org/OrgAdmin/HomeSection/api';
+import { uploadToS3 } from '@/components/org/OrgAdmin/HomeSection/api';
+import { CURRICULUM_WEEK_COUNT } from '@/components/org/OrgAdmin/RecruitSection/_constants/constants';
 import { ACTIVITY_GENERATION } from '@/utils/generation';
 import { FAQ_MAX_QUESTION_COUNT, PART_LIST } from '@/utils/org';
 
 import { soptFetcher } from '../api';
-
-const CURRICULUM_WEEK_COUNT = 8;
 
 type RecruitHeaderImageField = {
   fileName?: string;
@@ -42,7 +38,7 @@ export const postRecruitTabConfirm = async () => {
 };
 
 export type DeployRecruitInput = {
-  recruitHeaderImageFileName: string;
+  recruitHeaderImageFileName?: string;
   recruitHeaderImageFile?: File;
   partIntroduction: AddAdminRecruitRequestDto['partIntroduction'];
   partCurriculum: AddAdminRecruitRequestDto['partCurriculum'];
@@ -88,12 +84,13 @@ export const buildDeployRecruitInputFromForm = (
 
 export const resolveRecruitHeaderImageFileName = (
   recruitHeaderImage: RecruitHeaderImageField | undefined,
-  existingRecruitHeaderImageUrl?: string,
-) =>
-  recruitHeaderImage?.fileName ??
-  (existingRecruitHeaderImageUrl
-    ? extractFileNameFromUrl(existingRecruitHeaderImageUrl)
-    : '');
+) => {
+  const { file, fileName } = recruitHeaderImage ?? {};
+
+  if (!file || !fileName) return undefined;
+
+  return `${file.lastModified}-${file.size}-${fileName}`;
+};
 
 export const deployRecruitTab = async ({
   recruitHeaderImageFileName,
@@ -126,19 +123,14 @@ export const deployRecruitTab = async ({
   return postRecruitTabConfirm();
 };
 
-export const deployRecruitTabFromForm = async (
-  values: FieldValues,
-  existingRecruitHeaderImageUrl?: string,
-) => {
+export const deployRecruitTabFromForm = async (values: FieldValues) => {
   const recruitHeaderImage = values.recruitHeaderImage as
     | RecruitHeaderImageField
     | undefined;
 
   return deployRecruitTab({
-    recruitHeaderImageFileName: resolveRecruitHeaderImageFileName(
-      recruitHeaderImage,
-      existingRecruitHeaderImageUrl,
-    ),
+    recruitHeaderImageFileName:
+      resolveRecruitHeaderImageFileName(recruitHeaderImage),
     recruitHeaderImageFile: recruitHeaderImage?.file,
     ...buildDeployRecruitInputFromForm(values),
   });

--- a/src/components/org/OrgAdmin/RecruitSection/index.tsx
+++ b/src/components/org/OrgAdmin/RecruitSection/index.tsx
@@ -36,7 +36,11 @@ const RECRUIT_FIELD_NAMES = [
   'recruitQuestion',
 ];
 
-const RecruitSectionContent = () => {
+interface RecruitSectionProps {
+  onEditModeChange: (isEditing: boolean) => void;
+}
+
+const RecruitSectionContent = ({ onEditModeChange }: RecruitSectionProps) => {
   const [selectedParts, setSelectedParts] = useState<SelectedParts>({
     intro: '기획',
     curriculum: '기획',
@@ -63,6 +67,10 @@ const RecruitSectionContent = () => {
     JSON.stringify(watchedValues) !== JSON.stringify(snapshot);
 
   useEffect(() => {
+    onEditModeChange(isEditMode);
+  }, [isEditMode, onEditModeChange]);
+
+  useEffect(() => {
     syncRecruitFormFromAdminData(data, setValue);
   }, [data, setValue]);
 
@@ -80,7 +88,7 @@ const RecruitSectionContent = () => {
     return validationRecruitInputs(
       getValues,
       setError,
-      onChangeCurriculumPart,
+      onChangeIntroPart,
       onChangeFnaPart,
     );
   };
@@ -118,7 +126,6 @@ const RecruitSectionContent = () => {
     deployRecruit(
       {
         values: getValues(),
-        existingRecruitHeaderImageUrl: data?.recruitHeaderImage,
       },
       {
         onSuccess: exitEditMode,
@@ -171,11 +178,11 @@ const RecruitSectionContent = () => {
   );
 };
 
-const RecruitSection = () => {
+const RecruitSection = (props: RecruitSectionProps) => {
   return (
     <StRecruitContainer>
       <ToastProvider>
-        <RecruitSectionContent />
+        <RecruitSectionContent {...props} />
       </ToastProvider>
     </StRecruitContainer>
   );

--- a/src/components/org/OrgAdmin/RecruitSection/index.tsx
+++ b/src/components/org/OrgAdmin/RecruitSection/index.tsx
@@ -54,7 +54,7 @@ const RecruitSectionContent = ({ onEditModeChange }: RecruitSectionProps) => {
   const { mutate: deployRecruit, isLoading: isDeploying } =
     useDeployRecruitMutation();
 
-  const { control, getValues, setError, setValue, clearErrors } =
+  const { control, getValues, setError, setFocus, setValue, clearErrors } =
     useFormContext();
 
   const watchedValues = useWatch({ control, name: RECRUIT_FIELD_NAMES });
@@ -82,12 +82,14 @@ const RecruitSectionContent = ({ onEditModeChange }: RecruitSectionProps) => {
         type: 'required',
         message: VALIDATION_CHECK.required.errorText,
       });
+      setFocus('recruitHeaderImage');
       return false;
     }
 
     return validationRecruitInputs(
       getValues,
       setError,
+      setFocus,
       onChangeIntroPart,
       onChangeCurriculumPart,
       onChangeFnaPart,

--- a/src/components/org/OrgAdmin/RecruitSection/index.tsx
+++ b/src/components/org/OrgAdmin/RecruitSection/index.tsx
@@ -89,6 +89,7 @@ const RecruitSectionContent = ({ onEditModeChange }: RecruitSectionProps) => {
       getValues,
       setError,
       onChangeIntroPart,
+      onChangeCurriculumPart,
       onChangeFnaPart,
     );
   };

--- a/src/components/org/OrgAdmin/RecruitSection/queries.ts
+++ b/src/components/org/OrgAdmin/RecruitSection/queries.ts
@@ -7,7 +7,6 @@ import { deployRecruitTabFromForm } from '@/components/org/OrgAdmin/RecruitSecti
 
 type DeployRecruitTabFromFormInput = {
   values: FieldValues;
-  existingRecruitHeaderImageUrl?: string;
 };
 
 export const useDeployRecruitMutation = () => {
@@ -15,11 +14,8 @@ export const useDeployRecruitMutation = () => {
   const { open } = useToast();
 
   return useMutation({
-    mutationFn: ({
-      values,
-      existingRecruitHeaderImageUrl,
-    }: DeployRecruitTabFromFormInput) =>
-      deployRecruitTabFromForm(values, existingRecruitHeaderImageUrl),
+    mutationFn: ({ values }: DeployRecruitTabFromFormInput) =>
+      deployRecruitTabFromForm(values),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['admin'] });
       open(DEPLOY_TOAST_OPTION.success);

--- a/src/components/org/OrgAdmin/_hooks/usePageLeaveBlocker.ts
+++ b/src/components/org/OrgAdmin/_hooks/usePageLeaveBlocker.ts
@@ -5,34 +5,52 @@ interface RouterEventOptions {
   shallow: boolean;
 }
 
-export const usePageLeaveBlocker = () => {
-  const [blockedRoute, setBlockedRoute] = useState<string | null>(null);
+interface PendingLeave {
+  action: () => void;
+  allowsRouteChange: boolean;
+}
+
+export const usePageLeaveBlocker = (isEditing: boolean) => {
+  const [pendingLeave, setPendingLeave] = useState<PendingLeave | null>(null);
   const isLeaveAllowedRef = useRef(false);
 
   const router = useRouter();
 
-  const isPageLeaveModalOpen = blockedRoute !== null;
+  const isPageLeaveModalOpen = pendingLeave !== null;
 
   const onCancelPageLeave = () => {
-    setBlockedRoute(null);
+    setPendingLeave(null);
   };
 
   const onLeavePage = () => {
-    if (!blockedRoute) {
+    if (!pendingLeave) {
       return;
     }
 
-    isLeaveAllowedRef.current = true;
-    router.push(blockedRoute);
+    isLeaveAllowedRef.current = pendingLeave.allowsRouteChange;
+    setPendingLeave(null);
+    pendingLeave.action();
   };
 
-  const blockPageLeave = useCallback((url: string) => {
-    setBlockedRoute(url);
-  }, []);
+  const requestPageLeave = useCallback(
+    (leaveAction: () => void, allowsRouteChange = false) => {
+      if (!isEditing) {
+        leaveAction();
+        return;
+      }
+
+      setPendingLeave({ action: leaveAction, allowsRouteChange });
+    },
+    [isEditing],
+  );
 
   // 새로고침, 탭 닫기 차단
   useEffect(() => {
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!isEditing) {
+        return;
+      }
+
       event.preventDefault();
     };
     window.addEventListener('beforeunload', handleBeforeUnload);
@@ -40,16 +58,18 @@ export const usePageLeaveBlocker = () => {
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
-  }, []);
+  }, [isEditing]);
 
   // 브라우저 뒤로가기/앞으로가기 차단
   useEffect(() => {
     router.beforePopState(({ as }) => {
-      if (isLeaveAllowedRef.current || as === router.asPath) {
+      if (!isEditing || isLeaveAllowedRef.current || as === router.asPath) {
         return true;
       }
 
-      blockPageLeave(as);
+      requestPageLeave(() => {
+        void router.push(as);
+      }, true);
       window.history.pushState(null, '', router.asPath);
 
       return false;
@@ -58,7 +78,7 @@ export const usePageLeaveBlocker = () => {
     return () => {
       router.beforePopState(() => true);
     };
-  }, [blockPageLeave, router, router.asPath]);
+  }, [isEditing, requestPageLeave, router, router.asPath]);
 
   // Next.js 내부 라우트 이동 차단
   useEffect(() => {
@@ -66,11 +86,13 @@ export const usePageLeaveBlocker = () => {
       url: string,
       options: RouterEventOptions,
     ) => {
-      if (isLeaveAllowedRef.current || url === router.asPath) {
+      if (!isEditing || isLeaveAllowedRef.current || url === router.asPath) {
         return;
       }
 
-      blockPageLeave(url);
+      requestPageLeave(() => {
+        void router.push(url);
+      }, true);
 
       router.events.emit(
         'routeChangeError',
@@ -87,11 +109,12 @@ export const usePageLeaveBlocker = () => {
     return () => {
       router.events.off('routeChangeStart', handleRouteChangeStart);
     };
-  }, [blockPageLeave, router, router.asPath]);
+  }, [isEditing, requestPageLeave, router, router.asPath]);
 
   return {
     isPageLeaveModalOpen,
     onCancelPageLeave,
     onLeavePage,
+    requestPageLeave,
   };
 };

--- a/src/components/org/OrgAdmin/_hooks/usePageLeaveBlocker.ts
+++ b/src/components/org/OrgAdmin/_hooks/usePageLeaveBlocker.ts
@@ -6,8 +6,8 @@ interface RouterEventOptions {
 }
 
 interface PendingLeave {
-  action: () => void;
-  allowsRouteChange: boolean;
+  onLeavePage: () => void;
+  isRouteChangeAllowed: boolean;
 }
 
 export const usePageLeaveBlocker = (isEditing: boolean) => {
@@ -27,19 +27,19 @@ export const usePageLeaveBlocker = (isEditing: boolean) => {
       return;
     }
 
-    isLeaveAllowedRef.current = pendingLeave.allowsRouteChange;
+    isLeaveAllowedRef.current = pendingLeave.isRouteChangeAllowed;
     setPendingLeave(null);
-    pendingLeave.action();
+    pendingLeave.onLeavePage();
   };
 
   const requestPageLeave = useCallback(
-    (leaveAction: () => void, allowsRouteChange = false) => {
+    (onLeavePage: () => void, isRouteChangeAllowed = false) => {
       if (!isEditing) {
-        leaveAction();
+        onLeavePage();
         return;
       }
 
-      setPendingLeave({ action: leaveAction, allowsRouteChange });
+      setPendingLeave({ onLeavePage, isRouteChangeAllowed });
     },
     [isEditing],
   );

--- a/src/components/org/OrgAdmin/index.tsx
+++ b/src/components/org/OrgAdmin/index.tsx
@@ -17,14 +17,23 @@ function OrgAdmin() {
   const [selectedPart, setSelectedPart] = useState<ORG_ADMIN>('공통');
   const [group, setGroup] = useState<Group>('OB');
   const [selectedExec, setSelectedExec] = useState<EXEC_TYPE>('회장');
+  const [isEditing, setIsEditing] = useState(false);
 
-  const { isPageLeaveModalOpen, onCancelPageLeave, onLeavePage } =
-    usePageLeaveBlocker();
+  const {
+    isPageLeaveModalOpen,
+    onCancelPageLeave,
+    onLeavePage,
+    requestPageLeave,
+  } = usePageLeaveBlocker(isEditing);
 
   const methods = useForm({ mode: 'onBlur' });
 
   const onChangePart = (part: ORG_ADMIN): void => {
-    setSelectedPart(part);
+    if (part === selectedPart) {
+      return;
+    }
+
+    requestPageLeave(() => setSelectedPart(part));
   };
 
   return (
@@ -42,21 +51,23 @@ function OrgAdmin() {
           {selectedPart === '공통' ? (
             <CommonSection
               group={group}
+              onEditModeChange={setIsEditing}
               onChangeGroup={(group: Group) => {
                 setGroup(group);
               }}
             />
           ) : selectedPart === '홈' ? (
-            <HomeSection />
+            <HomeSection onEditModeChange={setIsEditing} />
           ) : selectedPart === '소개' ? (
             <AboutSection
               selectedExec={selectedExec}
+              onEditModeChange={setIsEditing}
               onChangeSelectedExec={(member: EXEC_TYPE) =>
                 setSelectedExec(member)
               }
             />
           ) : (
-            <RecruitSection />
+            <RecruitSection onEditModeChange={setIsEditing} />
           )}
         </form>
       </FormProvider>

--- a/src/components/org/OrgAdmin/utils.ts
+++ b/src/components/org/OrgAdmin/utils.ts
@@ -209,11 +209,9 @@ export const validationRecruitInputs = (
   setCurriculumPart: (curriculumPart: PART_KO) => void,
   setFnaPart: (fnaPart: PART_KO) => void,
 ) => {
-  const { recruitHeaderImage, recruitPartCurriculum, recruitQuestion } =
-    getValues();
+  const { recruitPartCurriculum, recruitQuestion } = getValues();
 
   const fieldsToValidate = [
-    { name: 'recruitHeaderImage', value: recruitHeaderImage },
     ...PART_LIST.flatMap((part) =>
       ['content', 'preference'].map((item) => ({
         name: `recruitPartCurriculum.${part}.${item}`,

--- a/src/components/org/OrgAdmin/utils.ts
+++ b/src/components/org/OrgAdmin/utils.ts
@@ -2,6 +2,7 @@ import type { FieldValues } from 'react-hook-form';
 
 import { CURRICULUM_WEEK_COUNT } from '@/components/org/OrgAdmin/RecruitSection/_constants/constants';
 import {
+  type EXEC_TYPE,
   FAQ_MAX_QUESTION_COUNT,
   type PART_KO,
   PART_LIST,
@@ -15,6 +16,7 @@ import type { Group } from './types';
 export const validationCommonInputs = (
   getValues: (payload?: string | string[]) => FieldValues,
   setError: (name: string, error: { type: string; message: string }) => void,
+  setFocus: (name: string) => void,
   setGroup: (group: Group) => void,
 ) => {
   const { generation, name, recruitSchedule, brandingColor } = getValues();
@@ -51,6 +53,7 @@ export const validationCommonInputs = (
       if (name.includes('YB')) setGroup('YB');
       else if (name.includes('OB')) setGroup('OB');
 
+      requestAnimationFrame(() => setFocus(name));
       return false;
     }
   }
@@ -61,6 +64,7 @@ export const validationCommonInputs = (
 export const validationHomeInputs = (
   getValues: (payload?: string | string[]) => FieldValues,
   setError: (name: string, error: { type: string; message: string }) => void,
+  setFocus: (name: string) => void,
   onChangeIntroPart: (part: PART_KO) => void,
 ) => {
   for (const part of PART_LIST) {
@@ -72,6 +76,7 @@ export const validationHomeInputs = (
         message: VALIDATION_CHECK.required.errorText,
       });
       onChangeIntroPart(part);
+      requestAnimationFrame(() => setFocus(name));
       return false;
     }
   }
@@ -81,6 +86,8 @@ export const validationHomeInputs = (
 export const validationAboutInputs = (
   getValues: (payload?: string | string[]) => FieldValues,
   setError: (name: string, error: { type: string; message: string }) => void,
+  setFocus: (name: string) => void,
+  onChangeSelectedExec: (execType: EXEC_TYPE) => void,
   existingHeaderImageUrl?: string,
   existingCoreValues?: { image?: string }[],
   existingMembers?: { role: string; profileImage?: string }[],
@@ -120,6 +127,7 @@ export const validationAboutInputs = (
         type: 'required',
         message: VALIDATION_CHECK.required.errorText,
       });
+      requestAnimationFrame(() => setFocus(name));
 
       break;
     }
@@ -160,6 +168,8 @@ export const validationAboutInputs = (
           type: 'required',
           message: VALIDATION_CHECK.required.errorText,
         });
+        onChangeSelectedExec(execType);
+        requestAnimationFrame(() => setFocus(name));
 
         return false;
       }
@@ -176,19 +186,23 @@ export const validationAboutInputs = (
     const row = scheduleRows?.[index];
 
     if (row?.date && !row?.session) {
-      setError(`activitySchedule.${index}.session`, {
+      const name = `activitySchedule.${index}.session`;
+      setError(name, {
         type: 'required',
         message: '세션명을 입력해주세요.',
       });
+      requestAnimationFrame(() => setFocus(name));
 
       return false;
     }
 
     if (!row?.date && row?.session) {
-      setError(`activitySchedule.${index}.date`, {
+      const name = `activitySchedule.${index}.date`;
+      setError(name, {
         type: 'required',
         message: '날짜를 입력해주세요.',
       });
+      requestAnimationFrame(() => setFocus(name));
 
       return false;
     }
@@ -198,10 +212,12 @@ export const validationAboutInputs = (
   const hasAnySchedule = scheduleRows?.some((row) => row?.date && row?.session);
 
   if (!hasAnySchedule) {
-    setError('activitySchedule.0.date', {
+    const name = 'activitySchedule.0.date';
+    setError(name, {
       type: 'required',
       message: '최소 1개 이상의 일정을 입력해주세요.',
     });
+    requestAnimationFrame(() => setFocus(name));
 
     return false;
   }
@@ -212,6 +228,7 @@ export const validationAboutInputs = (
 export const validationRecruitInputs = (
   getValues: (payload?: string | string[]) => FieldValues,
   setError: (name: string, error: { type: string; message: string }) => void,
+  setFocus: (name: string) => void,
   onInvalidIntroPart: (introPart: PART_KO) => void,
   onInvalidCurriculumPart: (curriculumPart: PART_KO) => void,
   onInvalidFaqPart: (faqPart: PART_KO) => void,
@@ -224,13 +241,21 @@ export const validationRecruitInputs = (
       message: VALIDATION_CHECK.required.errorText,
     });
   };
+  const focusInvalidField = (
+    name: string,
+    selectPart: (part: PART_KO) => void,
+    part: PART_KO,
+  ) => {
+    setRequiredError(name);
+    selectPart(part);
+    requestAnimationFrame(() => setFocus(name));
+  };
 
   for (const part of PART_LIST) {
     const name = `partIntroduction${part}`;
 
     if (!values[name]) {
-      setRequiredError(name);
-      onInvalidIntroPart(part);
+      focusInvalidField(name, onInvalidIntroPart, part);
       return false;
     }
   }
@@ -243,8 +268,7 @@ export const validationRecruitInputs = (
         item === 'preference' ? rawValue.replace(/\n/g, '').trim() : rawValue;
 
       if (!value) {
-        setRequiredError(name);
-        onInvalidIntroPart(part);
+        focusInvalidField(name, onInvalidIntroPart, part);
         return false;
       }
     }
@@ -255,8 +279,7 @@ export const validationRecruitInputs = (
       const name = `partCurriculum.${part}.${index}`;
 
       if (!partCurriculum?.[part]?.[index]) {
-        setRequiredError(name);
-        onInvalidCurriculumPart(part);
+        focusInvalidField(name, onInvalidCurriculumPart, part);
         return false;
       }
     }
@@ -275,14 +298,12 @@ export const validationRecruitInputs = (
       if (!question && !answer) continue;
 
       if (!question) {
-        setRequiredError(questionName);
-        onInvalidFaqPart(part);
+        focusInvalidField(questionName, onInvalidFaqPart, part);
         return false;
       }
 
       if (!answer) {
-        setRequiredError(answerName);
-        onInvalidFaqPart(part);
+        focusInvalidField(answerName, onInvalidFaqPart, part);
         return false;
       }
 
@@ -290,8 +311,11 @@ export const validationRecruitInputs = (
     }
 
     if (!hasCompletePair) {
-      setRequiredError(`recruitQuestion.${part}.question0`);
-      onInvalidFaqPart(part);
+      focusInvalidField(
+        `recruitQuestion.${part}.question0`,
+        onInvalidFaqPart,
+        part,
+      );
       return false;
     }
   }

--- a/src/components/org/OrgAdmin/utils.ts
+++ b/src/components/org/OrgAdmin/utils.ts
@@ -1,6 +1,12 @@
 import type { FieldValues } from 'react-hook-form';
 
-import { type PART_KO, PART_LIST, VALIDATION_CHECK } from '@/utils/org';
+import { CURRICULUM_WEEK_COUNT } from '@/components/org/OrgAdmin/RecruitSection/_constants/constants';
+import {
+  FAQ_MAX_QUESTION_COUNT,
+  type PART_KO,
+  PART_LIST,
+  VALIDATION_CHECK,
+} from '@/utils/org';
 
 import { EXEC_ROLE_LIST, toMemberRole } from './AboutSection/memberRole';
 import { BRANDING_COLOR_FIELD_IDS } from './CommonSection/BrandingColor';
@@ -206,52 +212,89 @@ export const validationAboutInputs = (
 export const validationRecruitInputs = (
   getValues: (payload?: string | string[]) => FieldValues,
   setError: (name: string, error: { type: string; message: string }) => void,
-  setCurriculumPart: (curriculumPart: PART_KO) => void,
-  setFnaPart: (fnaPart: PART_KO) => void,
+  onInvalidIntroPart: (introPart: PART_KO) => void,
+  onInvalidCurriculumPart: (curriculumPart: PART_KO) => void,
+  onInvalidFaqPart: (faqPart: PART_KO) => void,
 ) => {
-  const { recruitPartCurriculum, recruitQuestion } = getValues();
+  const values = getValues();
+  const { partCurriculum, recruitPartCurriculum, recruitQuestion } = values;
+  const setRequiredError = (name: string) => {
+    setError(name, {
+      type: 'required',
+      message: VALIDATION_CHECK.required.errorText,
+    });
+  };
 
-  const fieldsToValidate = [
-    ...PART_LIST.flatMap((part) =>
-      ['content', 'preference'].map((item) => ({
-        name: `recruitPartCurriculum.${part}.${item}`,
-        value: recruitPartCurriculum?.[part]?.[item],
-      })),
-    ),
-    ...PART_LIST.flatMap((part) =>
-      [
-        'answer0',
-        'answer1',
-        'answer2',
-        'question0',
-        'question1',
-        'question2',
-      ].map((item) => ({
-        name: `recruitQuestion.${part}.${item}`,
-        value: recruitQuestion?.[part]?.[item],
-      })),
-    ),
-  ];
+  for (const part of PART_LIST) {
+    const name = `partIntroduction${part}`;
 
-  let isAllFilled = true;
-
-  for (const { name, value } of fieldsToValidate) {
-    if (!value) {
-      isAllFilled = false;
-
-      setError(name, {
-        type: 'required',
-        message: VALIDATION_CHECK.required.errorText,
-      });
-
-      if (name.includes('recruitPartCurriculum'))
-        setCurriculumPart(name.split('.')[1] as PART_KO);
-      if (name.includes('recruitQuestion'))
-        setFnaPart(name.split('.')[1] as PART_KO);
-
-      break;
+    if (!values[name]) {
+      setRequiredError(name);
+      onInvalidIntroPart(part);
+      return false;
     }
   }
 
-  return isAllFilled;
+  for (const part of PART_LIST) {
+    for (const item of ['content', 'preference'] as const) {
+      const name = `recruitPartCurriculum.${part}.${item}`;
+      const rawValue = recruitPartCurriculum?.[part]?.[item] ?? '';
+      const value =
+        item === 'preference' ? rawValue.replace(/\n/g, '').trim() : rawValue;
+
+      if (!value) {
+        setRequiredError(name);
+        onInvalidIntroPart(part);
+        return false;
+      }
+    }
+  }
+
+  for (const part of PART_LIST) {
+    for (let index = 0; index < CURRICULUM_WEEK_COUNT; index += 1) {
+      const name = `partCurriculum.${part}.${index}`;
+
+      if (!partCurriculum?.[part]?.[index]) {
+        setRequiredError(name);
+        onInvalidCurriculumPart(part);
+        return false;
+      }
+    }
+  }
+
+  for (const part of PART_LIST) {
+    let hasCompletePair = false;
+    const partQuestions = recruitQuestion?.[part];
+
+    for (let index = 0; index < FAQ_MAX_QUESTION_COUNT; index += 1) {
+      const questionName = `recruitQuestion.${part}.question${index}`;
+      const answerName = `recruitQuestion.${part}.answer${index}`;
+      const question = (partQuestions?.[`question${index}`] ?? '').trim();
+      const answer = (partQuestions?.[`answer${index}`] ?? '').trim();
+
+      if (!question && !answer) continue;
+
+      if (!question) {
+        setRequiredError(questionName);
+        onInvalidFaqPart(part);
+        return false;
+      }
+
+      if (!answer) {
+        setRequiredError(answerName);
+        onInvalidFaqPart(part);
+        return false;
+      }
+
+      hasCompletePair = true;
+    }
+
+    if (!hasCompletePair) {
+      setRequiredError(`recruitQuestion.${part}.question0`);
+      onInvalidFaqPart(part);
+      return false;
+    }
+  }
+
+  return true;
 };


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] 이슈이름" 으로 작성 -->

## ✨ 구현 기능 명세

 - 공홈 관리의 공통, 홈, 소개, 모집안내 탭에서 수정 중 다른 탭으로 이동하면 이탈 경고 모달 표시
 - 모집안내 배포 시 필수값 검증
 - (모든 탭) 필수 값 누락 후 배포 버튼 클릭시 setFocus를 통해 누락된 부분으로 이동
  - 모집 안내 > 헤더 이미지 -> 새로 등록한 경우에만 파일명을 생성하고 업로드하도록 이미지 처리 로직 개선
  - 기존 모집 헤더 이미지를 유지한 상태에서도 배포 오류가 발생하지 않도록 수정

